### PR TITLE
feat: introduce DigitalAdapterFactory/PhysicalAdapterFactory registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,13 @@ Adapts the WHDT domain model to the WLDT execution runtime.
 
 Scaffolding for a planned ergonomic DSL that will let developers define HDTs in Kotlin without manually constructing the `HumanDigitalTwin` data class hierarchy. No sources yet.
 
+### Module versioning
+Each module is versioned following the *semantic versioning* conventions. Before publishing, it is imperative to adjust the
+version number according to what has been changed: leftmost for major, non retro-compatible changes, middle one for major, retro-compatible
+changes and rightmost one for minor changes. For each publication, only one number will be increased and only by one.
+
+N.B. before the publication of the first v1.0.0 modules, major changes only increase the middle number.
+
 ## Publishing
 
 Each publishable module reads its version from `<module>/version.txt`. The root `build.gradle.kts` also reads a `packageVersion` environment variable for the group-level version. Releases are automated via semantic-release (`scripts/release.mjs`, `package.json`).

--- a/whdt-wldt-plugin/build.gradle.kts
+++ b/whdt-wldt-plugin/build.gradle.kts
@@ -34,7 +34,9 @@ repositories {
 dependencies {
     implementation(project(":whdt-core"))
     implementation(project(":whdt-distributed"))
-    testImplementation(kotlin("test"))
+    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
+    testImplementation("io.kotest:kotest-assertions-core:5.8.0")
+    testImplementation("io.kotest:kotest-framework-engine:5.8.0")
 
     implementation("io.github.wldt:wldt-core:0.4.0")
     implementation("io.github.wldt:mqtt-physical-adapter:0.1.2")

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/HumanDigitalTwinFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/HumanDigitalTwinFactory.kt
@@ -1,53 +1,51 @@
 package io.github.whdt.wldt.plugin.factory
 
 import io.github.whdt.core.hdt.HumanDigitalTwin
-import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
-import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
-import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.storage.StorageType
-import io.github.whdt.distributed.namespace.Namespace
 import io.github.whdt.distributed.serde.Stub
+import io.github.whdt.wldt.plugin.factory.digital.DigitalAdapterRegistry
+import io.github.whdt.wldt.plugin.factory.digital.HttpDigitalAdapterFactory
+import io.github.whdt.wldt.plugin.factory.digital.MqttDigitalAdapterFactory
+import io.github.whdt.wldt.plugin.factory.physical.MqttPhysicalAdapterFactory
+import io.github.whdt.wldt.plugin.factory.physical.PhysicalAdapterRegistry
 import io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction
-import it.wldt.adapter.digital.DigitalAdapter
-import it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter
-import it.wldt.adapter.http.digital.adapter.HttpDigitalAdapterConfiguration
-import it.wldt.adapter.mqtt.digital.MqttDigitalAdapter
-import it.wldt.adapter.mqtt.digital.MqttDigitalAdapterConfiguration
-import it.wldt.adapter.mqtt.digital.topic.MqttQosLevel
-import it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter
-import it.wldt.adapter.mqtt.physical.MqttPhysicalAdapterConfiguration
-import it.wldt.adapter.physical.PhysicalAdapter
 import it.wldt.core.engine.DigitalTwin
 import it.wldt.storage.DefaultWldtStorage
 import java.util.logging.Logger
-import kotlin.time.ExperimentalTime
 
 object HumanDigitalTwinFactory {
     val logger: Logger = Logger.getLogger("HumanDigitalTwinFactory")
     val propertySerDe = Stub.propertyJsonSerDe()
 
-    fun fromHumanDigitalTwin(hdt: HumanDigitalTwin): DigitalTwin {
+    private val digitalRegistry = DigitalAdapterRegistry(
+        listOf(
+            MqttDigitalAdapterFactory(propertySerDe),
+            HttpDigitalAdapterFactory(),
+        )
+    )
 
+    private val physicalRegistry = PhysicalAdapterRegistry(
+        listOf(
+            MqttPhysicalAdapterFactory(propertySerDe),
+        )
+    )
+
+    fun fromHumanDigitalTwin(hdt: HumanDigitalTwin): DigitalTwin {
         val shad = WhdtShadowingFunction("${hdt.hdtId}-shadowing-function", hdt.models)
         val dt = DigitalTwin(hdt.hdtId.id, shad)
 
         val properties = hdt.models.flatMap { it.properties }
 
+        physicalRegistry.validateAll(hdt.physicalInterfaces).getOrThrow()
         hdt.physicalInterfaces.forEach { pI ->
-            val pa: PhysicalAdapter? = when (pI.interfaceType) {
-                PhysicalInterfaceType.MQTT -> getPaFromPhysicalInterfaceMqtt(pI, properties)
-            }
-            if (pa != null) dt.addPhysicalAdapter(pa)
+            physicalRegistry.create(pI, properties)?.let { dt.addPhysicalAdapter(it) }
+                ?: logger.warning("no factory registered for interface type ${pI.interfaceType}")
         }
 
+        digitalRegistry.validateAll(hdt.digitalInterfaces).getOrThrow()
         hdt.digitalInterfaces.forEach { dI ->
-            val da: DigitalAdapter<*>? = when (dI.interfaceType) {
-                DigitalInterfaceType.MQTT -> getDaFromDigitalInterfaceMqtt(dI, properties)
-                DigitalInterfaceType.HTTP -> getDaFromHttpDigitalInterface(dI, dt, properties)
-            }
-            if (da != null) dt.addDigitalAdapter(da)
+            digitalRegistry.create(dI, dt, properties)?.let { dt.addDigitalAdapter(it) }
+                ?: logger.warning("no factory registered for interface type ${dI.interfaceType}")
         }
 
         val storages = hdt.storages.map { storage ->
@@ -60,52 +58,5 @@ object HumanDigitalTwinFactory {
         storages.forEach { dt.storageManager.putStorage(it) }
 
         return dt
-    }
-
-    fun getPaFromPhysicalInterfaceMqtt(pI: PhysicalInterface, properties: List<Property>): MqttPhysicalAdapter {
-        val broker = pI.optionalString("broker", "localhost")
-        val port = pI.optionalInt("port", 1883)
-        val mqttConfigBuilder = MqttPhysicalAdapterConfiguration.builder(broker, port)
-
-        properties.forEach { property ->
-            mqttConfigBuilder.addPhysicalAssetPropertyAndTopic(
-                property.id.toString(),
-                property,
-                Namespace.propertyUpdateRequestTopic(pI.hdtId, property.name)
-            ) { string ->
-                propertySerDe.deserialize(string)
-            }
-        }
-
-        return MqttPhysicalAdapter(pI.id.toString(), mqttConfigBuilder.build())
-    }
-
-    @OptIn(ExperimentalTime::class)
-    fun getDaFromDigitalInterfaceMqtt(dI: DigitalInterface, properties: List<Property>): MqttDigitalAdapter {
-        val broker = dI.optionalString("broker", "localhost")
-        val port = dI.optionalInt("port", 1883)
-        val mqttConfigBuilder = MqttDigitalAdapterConfiguration.builder(broker, port)
-
-        properties.forEach { property ->
-            mqttConfigBuilder.addPropertyTopic(
-                property.id.toString(),
-                Namespace.propertyUpdateNotificationTopic(dI.hdtId, property.name),
-                MqttQosLevel.MQTT_QOS_0
-            ) { p: Property ->
-                propertySerDe.serialize(p)
-            }
-        }
-
-        return MqttDigitalAdapter(dI.id.toString(), mqttConfigBuilder.build())
-    }
-
-    fun getDaFromHttpDigitalInterface(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): HttpDigitalAdapter {
-        val host = dI.optionalString("host", "localhost")
-        val port = dI.optionalInt("port", 8080)
-        val httpConfig = HttpDigitalAdapterConfiguration(dI.id.toString(), host, port)
-
-        httpConfig.addPropertiesFilter(properties.map { it.id.toString() })
-
-        return HttpDigitalAdapter(httpConfig, dt)
     }
 }

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterFactory.kt
@@ -1,0 +1,23 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import it.wldt.adapter.digital.DigitalAdapter
+import it.wldt.core.engine.DigitalTwin
+
+interface DigitalAdapterFactory {
+    val interfaceType: DigitalInterfaceType
+
+    /**
+     * Returns Result.success(Unit) if the config is well-formed for this factory.
+     * Returns Result.failure(ConfigException) if any required key is missing or any present key is malformed.
+     * Validation must not have side effects.
+     */
+    fun validate(dI: DigitalInterface): Result<Unit>
+
+    /**
+     * Constructs the adapter. Caller must validate first; create() may throw on bad config.
+     */
+    fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*>
+}

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistry.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistry.kt
@@ -1,0 +1,37 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import it.wldt.adapter.digital.DigitalAdapter
+import it.wldt.core.engine.DigitalTwin
+
+class DigitalAdapterRegistry(factories: List<DigitalAdapterFactory>) {
+    private val byType: Map<DigitalInterfaceType, DigitalAdapterFactory> =
+        factories.associateBy { it.interfaceType }
+
+    /**
+     * Eager validation across all configured interfaces.
+     * Aggregates ALL errors before returning — does not short-circuit on first failure.
+     */
+    fun validateAll(interfaces: List<DigitalInterface>): Result<Unit> {
+        val errors = mutableListOf<String>()
+        interfaces.forEach { dI ->
+            val factory = byType[dI.interfaceType]
+            if (factory == null) {
+                errors += "interface ${dI.id}: no factory registered for type ${dI.interfaceType}"
+            } else {
+                factory.validate(dI).onFailure { e ->
+                    errors += "interface ${dI.id}: ${e.message}"
+                }
+            }
+        }
+        return if (errors.isEmpty()) Result.success(Unit)
+        else Result.failure(
+            IllegalStateException("config validation failed:\n - " + errors.joinToString("\n - "))
+        )
+    }
+
+    fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*>? =
+        byType[dI.interfaceType]?.create(dI, dt, properties)
+}

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactory.kt
@@ -1,0 +1,30 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter
+import it.wldt.adapter.http.digital.adapter.HttpDigitalAdapterConfiguration
+import it.wldt.core.engine.DigitalTwin
+
+class HttpDigitalAdapterFactory : DigitalAdapterFactory {
+    override val interfaceType = DigitalInterfaceType.HTTP
+
+    override fun validate(dI: DigitalInterface): Result<Unit> = runCatching {
+        dI.optionalString("host", DEFAULT_HOST)
+        dI.optionalInt("port", DEFAULT_PORT)
+    }
+
+    override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): HttpDigitalAdapter {
+        val host = dI.optionalString("host", DEFAULT_HOST)
+        val port = dI.optionalInt("port", DEFAULT_PORT)
+        val httpConfig = HttpDigitalAdapterConfiguration(dI.id.toString(), host, port)
+        httpConfig.addPropertiesFilter(properties.map { it.id.toString() })
+        return HttpDigitalAdapter(httpConfig, dt)
+    }
+
+    private companion object {
+        const val DEFAULT_HOST = "localhost"
+        const val DEFAULT_PORT = 8080
+    }
+}

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactory.kt
@@ -1,0 +1,43 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.distributed.namespace.Namespace
+import io.github.whdt.distributed.serde.SerDe
+import it.wldt.adapter.mqtt.digital.MqttDigitalAdapter
+import it.wldt.adapter.mqtt.digital.MqttDigitalAdapterConfiguration
+import it.wldt.adapter.mqtt.digital.topic.MqttQosLevel
+import it.wldt.core.engine.DigitalTwin
+import kotlin.time.ExperimentalTime
+
+class MqttDigitalAdapterFactory(
+    private val propertySerDe: SerDe<Property>,
+) : DigitalAdapterFactory {
+    override val interfaceType = DigitalInterfaceType.MQTT
+
+    override fun validate(dI: DigitalInterface): Result<Unit> = runCatching {
+        dI.optionalString("broker", DEFAULT_BROKER)
+        dI.optionalInt("port", DEFAULT_PORT)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): MqttDigitalAdapter {
+        val broker = dI.optionalString("broker", DEFAULT_BROKER)
+        val port = dI.optionalInt("port", DEFAULT_PORT)
+        val builder = MqttDigitalAdapterConfiguration.builder(broker, port)
+        properties.forEach { property ->
+            builder.addPropertyTopic(
+                property.id.toString(),
+                Namespace.propertyUpdateNotificationTopic(dI.hdtId, property.name),
+                MqttQosLevel.MQTT_QOS_0
+            ) { p: Property -> propertySerDe.serialize(p) }
+        }
+        return MqttDigitalAdapter(dI.id.toString(), builder.build())
+    }
+
+    private companion object {
+        const val DEFAULT_BROKER = "localhost"
+        const val DEFAULT_PORT = 1883
+    }
+}

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactory.kt
@@ -1,0 +1,41 @@
+package io.github.whdt.wldt.plugin.factory.physical
+
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.distributed.namespace.Namespace
+import io.github.whdt.distributed.serde.SerDe
+import it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter
+import it.wldt.adapter.mqtt.physical.MqttPhysicalAdapterConfiguration
+
+class MqttPhysicalAdapterFactory(
+    private val propertySerDe: SerDe<Property>,
+) : PhysicalAdapterFactory {
+    override val interfaceType = PhysicalInterfaceType.MQTT
+
+    override fun validate(pI: PhysicalInterface): Result<Unit> = runCatching {
+        pI.optionalString("broker", DEFAULT_BROKER)
+        pI.optionalInt("port", DEFAULT_PORT)
+    }
+
+    override fun create(pI: PhysicalInterface, properties: List<Property>): MqttPhysicalAdapter {
+        val broker = pI.optionalString("broker", DEFAULT_BROKER)
+        val port = pI.optionalInt("port", DEFAULT_PORT)
+        val builder = MqttPhysicalAdapterConfiguration.builder(broker, port)
+        properties.forEach { property ->
+            builder.addPhysicalAssetPropertyAndTopic(
+                property.id.toString(),
+                property,
+                Namespace.propertyUpdateRequestTopic(pI.hdtId, property.name)
+            ) { string ->
+                propertySerDe.deserialize(string)
+            }
+        }
+        return MqttPhysicalAdapter(pI.id.toString(), builder.build())
+    }
+
+    private companion object {
+        const val DEFAULT_BROKER = "localhost"
+        const val DEFAULT_PORT = 1883
+    }
+}

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterFactory.kt
@@ -1,0 +1,22 @@
+package io.github.whdt.wldt.plugin.factory.physical
+
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import it.wldt.adapter.physical.PhysicalAdapter
+
+interface PhysicalAdapterFactory {
+    val interfaceType: PhysicalInterfaceType
+
+    /**
+     * Returns Result.success(Unit) if the config is well-formed for this factory.
+     * Returns Result.failure(ConfigException) if any required key is missing or any present key is malformed.
+     * Validation must not have side effects.
+     */
+    fun validate(pI: PhysicalInterface): Result<Unit>
+
+    /**
+     * Constructs the adapter. Caller must validate first; create() may throw on bad config.
+     */
+    fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter
+}

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistry.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistry.kt
@@ -1,0 +1,36 @@
+package io.github.whdt.wldt.plugin.factory.physical
+
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import it.wldt.adapter.physical.PhysicalAdapter
+
+class PhysicalAdapterRegistry(factories: List<PhysicalAdapterFactory>) {
+    private val byType: Map<PhysicalInterfaceType, PhysicalAdapterFactory> =
+        factories.associateBy { it.interfaceType }
+
+    /**
+     * Eager validation across all configured interfaces.
+     * Aggregates ALL errors before returning — does not short-circuit on first failure.
+     */
+    fun validateAll(interfaces: List<PhysicalInterface>): Result<Unit> {
+        val errors = mutableListOf<String>()
+        interfaces.forEach { pI ->
+            val factory = byType[pI.interfaceType]
+            if (factory == null) {
+                errors += "interface ${pI.id}: no factory registered for type ${pI.interfaceType}"
+            } else {
+                factory.validate(pI).onFailure { e ->
+                    errors += "interface ${pI.id}: ${e.message}"
+                }
+            }
+        }
+        return if (errors.isEmpty()) Result.success(Unit)
+        else Result.failure(
+            IllegalStateException("config validation failed:\n - " + errors.joinToString("\n - "))
+        )
+    }
+
+    fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter? =
+        byType[pI.interfaceType]?.create(pI, properties)
+}

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistryTest.kt
@@ -1,0 +1,137 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import it.wldt.adapter.digital.DigitalAdapter
+import it.wldt.core.engine.DigitalTwin
+
+class DigitalAdapterRegistryTest : FunSpec({
+
+    fun di(
+        type: DigitalInterfaceType,
+        name: String = "test-di",
+        config: Map<String, String> = emptyMap(),
+    ) = DigitalInterface(
+        interfaceType = type,
+        hdtId = HdtId("test-hdt"),
+        name = DigitalInterfaceName(name),
+        config = config,
+    )
+
+    val alwaysOkFactory = object : DigitalAdapterFactory {
+        override val interfaceType = DigitalInterfaceType.MQTT
+        override fun validate(dI: DigitalInterface): Result<Unit> = Result.success(Unit)
+        override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> =
+            error("not used in registry tests")
+    }
+
+    val alwaysFailFactory = object : DigitalAdapterFactory {
+        override val interfaceType = DigitalInterfaceType.HTTP
+        override fun validate(dI: DigitalInterface): Result<Unit> =
+            Result.failure(IllegalArgumentException("bad config for ${dI.id}"))
+        override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> =
+            error("not used in registry tests")
+    }
+
+    context("validateAll") {
+        test("returns success for empty interface list") {
+            val registry = DigitalAdapterRegistry(listOf(alwaysOkFactory))
+            registry.validateAll(emptyList()) shouldBeSuccess Unit
+        }
+
+        test("returns success when all interfaces validate") {
+            val registry = DigitalAdapterRegistry(listOf(alwaysOkFactory))
+            registry.validateAll(listOf(di(DigitalInterfaceType.MQTT))) shouldBeSuccess Unit
+        }
+
+        test("returns failure for a single failing interface") {
+            val registry = DigitalAdapterRegistry(listOf(alwaysOkFactory, alwaysFailFactory))
+            val result = registry.validateAll(listOf(di(DigitalInterfaceType.HTTP)))
+            result shouldBeFailure { e ->
+                e.message shouldContain "bad config"
+            }
+        }
+
+        test("aggregates multiple errors without short-circuiting") {
+            val registry = DigitalAdapterRegistry(listOf(alwaysOkFactory, alwaysFailFactory))
+            val interfaces = listOf(
+                di(DigitalInterfaceType.HTTP, "di-1"),
+                di(DigitalInterfaceType.HTTP, "di-2"),
+            )
+            val result = registry.validateAll(interfaces)
+            result shouldBeFailure { e ->
+                e.message shouldContain "di-1"
+                e.message shouldContain "di-2"
+            }
+        }
+
+        test("aggregates errors from different factories") {
+            val anotherFailFactory = object : DigitalAdapterFactory {
+                override val interfaceType = DigitalInterfaceType.MQTT
+                override fun validate(dI: DigitalInterface): Result<Unit> =
+                    Result.failure(IllegalArgumentException("mqtt fail for ${dI.id}"))
+                override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> =
+                    error("not used")
+            }
+            val registry = DigitalAdapterRegistry(listOf(anotherFailFactory, alwaysFailFactory))
+            val interfaces = listOf(
+                di(DigitalInterfaceType.MQTT, "di-mqtt"),
+                di(DigitalInterfaceType.HTTP, "di-http"),
+            )
+            val result = registry.validateAll(interfaces)
+            result shouldBeFailure { e ->
+                e.message shouldContain "di-mqtt"
+                e.message shouldContain "di-http"
+            }
+        }
+
+        test("returns failure for unknown interface type") {
+            val registry = DigitalAdapterRegistry(listOf(alwaysOkFactory))
+            val result = registry.validateAll(listOf(di(DigitalInterfaceType.HTTP)))
+            result shouldBeFailure { e ->
+                e.message shouldContain "no factory registered"
+                e.message shouldContain "HTTP"
+            }
+        }
+    }
+
+    context("create") {
+        test("returns null for unknown interface type") {
+            val registry = DigitalAdapterRegistry(listOf(alwaysOkFactory))
+            registry.create(di(DigitalInterfaceType.HTTP), mockDigitalTwin(), emptyList()) shouldBe null
+        }
+
+        test("delegates to the matching factory") {
+            val sentinel = object {}
+            val capturingFactory = object : DigitalAdapterFactory {
+                var called = false
+                override val interfaceType = DigitalInterfaceType.MQTT
+                override fun validate(dI: DigitalInterface): Result<Unit> = Result.success(Unit)
+                override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> {
+                    called = true
+                    error("sentinel — not a real adapter") // won't reach assertion check
+                }
+            }
+            val registry = DigitalAdapterRegistry(listOf(capturingFactory))
+            shouldThrow<IllegalStateException> {
+                registry.create(di(DigitalInterfaceType.MQTT), mockDigitalTwin(), emptyList())
+            }
+            capturingFactory.called shouldBe true
+        }
+    }
+})
+
+private fun mockDigitalTwin(): DigitalTwin = DigitalTwin(
+    "mock-dt",
+    io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
+)

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactoryTest.kt
@@ -4,12 +4,19 @@ import io.github.whdt.core.hdt.HdtId
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 class HttpDigitalAdapterFactoryTest : FunSpec({
 
@@ -49,12 +56,12 @@ class HttpDigitalAdapterFactoryTest : FunSpec({
         test("returns an HttpDigitalAdapter") {
             val dI = di()
             val dt = mockDigitalTwin()
-            val adapter = factory.create(dI, dt, emptyList())
+            val adapter = factory.create(dI, dt, listOf(testProperty()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
         }
 
         test("applies default host and port when config is empty") {
-            val adapter = factory.create(di(), mockDigitalTwin(), emptyList())
+            val adapter = factory.create(di(), mockDigitalTwin(), listOf(testProperty()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
         }
 
@@ -62,7 +69,7 @@ class HttpDigitalAdapterFactoryTest : FunSpec({
             val adapter = factory.create(
                 di(mapOf("host" to "custom.host", "port" to "9090")),
                 mockDigitalTwin(),
-                emptyList(),
+                listOf(testProperty()),
             )
             adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
         }
@@ -72,4 +79,13 @@ class HttpDigitalAdapterFactoryTest : FunSpec({
 private fun mockDigitalTwin() = it.wldt.core.engine.DigitalTwin(
     "mock-dt",
     io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
+)
+
+@OptIn(ExperimentalTime::class)
+private fun testProperty() = Property(
+    modelId = ModelId("test-model"),
+    name = PropertyName("test-prop"),
+    description = PropertyDescription(""),
+    timestamp = Clock.System.now(),
+    value = PropertyValue.StringPropertyValue("value"),
 )

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactoryTest.kt
@@ -1,0 +1,75 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class HttpDigitalAdapterFactoryTest : FunSpec({
+
+    val factory = HttpDigitalAdapterFactory()
+
+    fun di(config: Map<String, String> = emptyMap()) = DigitalInterface(
+        interfaceType = DigitalInterfaceType.HTTP,
+        hdtId = HdtId("test-hdt"),
+        name = DigitalInterfaceName("test-http-di"),
+        config = config,
+    )
+
+    context("interfaceType") {
+        test("is HTTP") {
+            factory.interfaceType shouldBe DigitalInterfaceType.HTTP
+        }
+    }
+
+    context("validate") {
+        test("succeeds with empty config (all keys have defaults)") {
+            factory.validate(di()) shouldBeSuccess Unit
+        }
+
+        test("succeeds with valid host and port") {
+            factory.validate(di(mapOf("host" to "api.local", "port" to "8080"))) shouldBeSuccess Unit
+        }
+
+        test("fails when port is malformed") {
+            val result = factory.validate(di(mapOf("port" to "not-a-number")))
+            result shouldBeFailure { e ->
+                e.message shouldContain "port"
+            }
+        }
+    }
+
+    context("create") {
+        test("returns an HttpDigitalAdapter") {
+            val dI = di()
+            val dt = mockDigitalTwin()
+            val adapter = factory.create(dI, dt, emptyList())
+            adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
+        }
+
+        test("applies default host and port when config is empty") {
+            val adapter = factory.create(di(), mockDigitalTwin(), emptyList())
+            adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
+        }
+
+        test("uses provided host and port from config") {
+            val adapter = factory.create(
+                di(mapOf("host" to "custom.host", "port" to "9090")),
+                mockDigitalTwin(),
+                emptyList(),
+            )
+            adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
+        }
+    }
+})
+
+private fun mockDigitalTwin() = it.wldt.core.engine.DigitalTwin(
+    "mock-dt",
+    io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
+)

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactoryTest.kt
@@ -4,6 +4,11 @@ import io.github.whdt.core.hdt.HdtId
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValue
 import io.github.whdt.distributed.serde.Stub
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
@@ -11,6 +16,8 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 class MqttDigitalAdapterFactoryTest : FunSpec({
 
@@ -53,13 +60,13 @@ class MqttDigitalAdapterFactoryTest : FunSpec({
     context("create") {
         test("returns a MqttDigitalAdapter with the correct id") {
             val dI = di()
-            val adapter = factory.create(dI, mockDigitalTwin(), emptyList())
+            val adapter = factory.create(dI, mockDigitalTwin(), listOf(testProperty()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
             adapter.id shouldBe dI.id.toString()
         }
 
         test("applies default broker and port when config is empty") {
-            val adapter = factory.create(di(), mockDigitalTwin(), emptyList())
+            val adapter = factory.create(di(), mockDigitalTwin(), listOf(testProperty()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
         }
 
@@ -67,7 +74,7 @@ class MqttDigitalAdapterFactoryTest : FunSpec({
             val adapter = factory.create(
                 di(mapOf("broker" to "custom.broker", "port" to "1884")),
                 mockDigitalTwin(),
-                emptyList(),
+                listOf(testProperty()),
             )
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
         }
@@ -77,4 +84,13 @@ class MqttDigitalAdapterFactoryTest : FunSpec({
 private fun mockDigitalTwin() = it.wldt.core.engine.DigitalTwin(
     "mock-dt",
     io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
+)
+
+@OptIn(ExperimentalTime::class)
+private fun testProperty() = Property(
+    modelId = ModelId("test-model"),
+    name = PropertyName("test-prop"),
+    description = PropertyDescription(""),
+    timestamp = Clock.System.now(),
+    value = PropertyValue.StringPropertyValue("value"),
 )

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactoryTest.kt
@@ -1,0 +1,80 @@
+package io.github.whdt.wldt.plugin.factory.digital
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
+import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
+import io.github.whdt.distributed.serde.Stub
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class MqttDigitalAdapterFactoryTest : FunSpec({
+
+    val factory = MqttDigitalAdapterFactory(Stub.propertyJsonSerDe())
+
+    fun di(config: Map<String, String> = emptyMap()) = DigitalInterface(
+        interfaceType = DigitalInterfaceType.MQTT,
+        hdtId = HdtId("test-hdt"),
+        name = DigitalInterfaceName("test-mqtt-di"),
+        config = config,
+    )
+
+    context("interfaceType") {
+        test("is MQTT") {
+            factory.interfaceType shouldBe DigitalInterfaceType.MQTT
+        }
+    }
+
+    context("validate") {
+        test("succeeds with empty config (all keys have defaults)") {
+            factory.validate(di()) shouldBeSuccess Unit
+        }
+
+        test("succeeds with valid broker and port") {
+            factory.validate(di(mapOf("broker" to "mqtt.local", "port" to "1883"))) shouldBeSuccess Unit
+        }
+
+        test("fails when port is malformed") {
+            val result = factory.validate(di(mapOf("port" to "not-a-number")))
+            result shouldBeFailure { e ->
+                e.message shouldContain "port"
+            }
+        }
+
+        test("fails when broker key is present but empty string is accepted") {
+            factory.validate(di(mapOf("broker" to ""))) shouldBeSuccess Unit
+        }
+    }
+
+    context("create") {
+        test("returns a MqttDigitalAdapter with the correct id") {
+            val dI = di()
+            val adapter = factory.create(dI, mockDigitalTwin(), emptyList())
+            adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
+            adapter.id shouldBe dI.id.toString()
+        }
+
+        test("applies default broker and port when config is empty") {
+            val adapter = factory.create(di(), mockDigitalTwin(), emptyList())
+            adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
+        }
+
+        test("uses provided broker and port from config") {
+            val adapter = factory.create(
+                di(mapOf("broker" to "custom.broker", "port" to "1884")),
+                mockDigitalTwin(),
+                emptyList(),
+            )
+            adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
+        }
+    }
+})
+
+private fun mockDigitalTwin() = it.wldt.core.engine.DigitalTwin(
+    "mock-dt",
+    io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
+)

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactoryTest.kt
@@ -4,6 +4,11 @@ import io.github.whdt.core.hdt.HdtId
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceName
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValue
 import io.github.whdt.distributed.serde.Stub
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
@@ -11,6 +16,8 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 class MqttPhysicalAdapterFactoryTest : FunSpec({
 
@@ -49,22 +56,31 @@ class MqttPhysicalAdapterFactoryTest : FunSpec({
     context("create") {
         test("returns a MqttPhysicalAdapter with the correct id") {
             val pI = pi()
-            val adapter = factory.create(pI, emptyList())
+            val adapter = factory.create(pI, listOf(testProperty()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
             adapter.id shouldBe pI.id.toString()
         }
 
         test("applies default broker and port when config is empty") {
-            val adapter = factory.create(pi(), emptyList())
+            val adapter = factory.create(pi(), listOf(testProperty()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
         }
 
         test("uses provided broker and port from config") {
             val adapter = factory.create(
                 pi(mapOf("broker" to "custom.broker", "port" to "1884")),
-                emptyList(),
+                listOf(testProperty()),
             )
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
         }
     }
 })
+
+@OptIn(ExperimentalTime::class)
+private fun testProperty() = Property(
+    modelId = ModelId("test-model"),
+    name = PropertyName("test-prop"),
+    description = PropertyDescription(""),
+    timestamp = Clock.System.now(),
+    value = PropertyValue.StringPropertyValue("value"),
+)

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactoryTest.kt
@@ -1,0 +1,70 @@
+package io.github.whdt.wldt.plugin.factory.physical
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceName
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
+import io.github.whdt.distributed.serde.Stub
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class MqttPhysicalAdapterFactoryTest : FunSpec({
+
+    val factory = MqttPhysicalAdapterFactory(Stub.propertyJsonSerDe())
+
+    fun pi(config: Map<String, String> = emptyMap()) = PhysicalInterface(
+        interfaceType = PhysicalInterfaceType.MQTT,
+        hdtId = HdtId("test-hdt"),
+        name = PhysicalInterfaceName("test-mqtt-pi"),
+        config = config,
+    )
+
+    context("interfaceType") {
+        test("is MQTT") {
+            factory.interfaceType shouldBe PhysicalInterfaceType.MQTT
+        }
+    }
+
+    context("validate") {
+        test("succeeds with empty config (all keys have defaults)") {
+            factory.validate(pi()) shouldBeSuccess Unit
+        }
+
+        test("succeeds with valid broker and port") {
+            factory.validate(pi(mapOf("broker" to "mqtt.local", "port" to "1883"))) shouldBeSuccess Unit
+        }
+
+        test("fails when port is malformed") {
+            val result = factory.validate(pi(mapOf("port" to "not-a-number")))
+            result shouldBeFailure { e ->
+                e.message shouldContain "port"
+            }
+        }
+    }
+
+    context("create") {
+        test("returns a MqttPhysicalAdapter with the correct id") {
+            val pI = pi()
+            val adapter = factory.create(pI, emptyList())
+            adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
+            adapter.id shouldBe pI.id.toString()
+        }
+
+        test("applies default broker and port when config is empty") {
+            val adapter = factory.create(pi(), emptyList())
+            adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
+        }
+
+        test("uses provided broker and port from config") {
+            val adapter = factory.create(
+                pi(mapOf("broker" to "custom.broker", "port" to "1884")),
+                emptyList(),
+            )
+            adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
+        }
+    }
+})

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistryTest.kt
@@ -1,0 +1,105 @@
+package io.github.whdt.wldt.plugin.factory.physical
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceName
+import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
+import io.github.whdt.core.hdt.model.property.Property
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import it.wldt.adapter.physical.PhysicalAdapter
+
+class PhysicalAdapterRegistryTest : FunSpec({
+
+    fun pi(
+        name: String = "test-pi",
+        config: Map<String, String> = emptyMap(),
+    ) = PhysicalInterface(
+        interfaceType = PhysicalInterfaceType.MQTT,
+        hdtId = HdtId("test-hdt"),
+        name = PhysicalInterfaceName(name),
+        config = config,
+    )
+
+    val alwaysOkFactory = object : PhysicalAdapterFactory {
+        override val interfaceType = PhysicalInterfaceType.MQTT
+        override fun validate(pI: PhysicalInterface): Result<Unit> = Result.success(Unit)
+        override fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter =
+            error("not used in registry tests")
+    }
+
+    val alwaysFailFactory = object : PhysicalAdapterFactory {
+        override val interfaceType = PhysicalInterfaceType.MQTT
+        override fun validate(pI: PhysicalInterface): Result<Unit> =
+            Result.failure(IllegalArgumentException("bad config for ${pI.id}"))
+        override fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter =
+            error("not used in registry tests")
+    }
+
+    context("validateAll") {
+        test("returns success for empty interface list") {
+            val registry = PhysicalAdapterRegistry(listOf(alwaysOkFactory))
+            registry.validateAll(emptyList()) shouldBeSuccess Unit
+        }
+
+        test("returns success when all interfaces validate") {
+            val registry = PhysicalAdapterRegistry(listOf(alwaysOkFactory))
+            registry.validateAll(listOf(pi())) shouldBeSuccess Unit
+        }
+
+        test("returns failure for a single failing interface") {
+            val registry = PhysicalAdapterRegistry(listOf(alwaysFailFactory))
+            val result = registry.validateAll(listOf(pi()))
+            result shouldBeFailure { e ->
+                e.message shouldContain "bad config"
+            }
+        }
+
+        test("aggregates multiple errors without short-circuiting") {
+            val registry = PhysicalAdapterRegistry(listOf(alwaysFailFactory))
+            val interfaces = listOf(pi("pi-1"), pi("pi-2"))
+            val result = registry.validateAll(interfaces)
+            result shouldBeFailure { e ->
+                e.message shouldContain "pi-1"
+                e.message shouldContain "pi-2"
+            }
+        }
+
+        test("returns failure for unknown interface type — registry has no factory") {
+            val registry = PhysicalAdapterRegistry(emptyList())
+            val result = registry.validateAll(listOf(pi()))
+            result shouldBeFailure { e ->
+                e.message shouldContain "no factory registered"
+                e.message shouldContain "MQTT"
+            }
+        }
+    }
+
+    context("create") {
+        test("returns null for unknown interface type") {
+            val registry = PhysicalAdapterRegistry(emptyList())
+            registry.create(pi(), emptyList()) shouldBe null
+        }
+
+        test("delegates to the matching factory") {
+            val capturingFactory = object : PhysicalAdapterFactory {
+                var called = false
+                override val interfaceType = PhysicalInterfaceType.MQTT
+                override fun validate(pI: PhysicalInterface): Result<Unit> = Result.success(Unit)
+                override fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter {
+                    called = true
+                    error("sentinel — not a real adapter")
+                }
+            }
+            val registry = PhysicalAdapterRegistry(listOf(capturingFactory))
+            shouldThrow<IllegalStateException> {
+                registry.create(pi(), emptyList())
+            }
+            capturingFactory.called shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
Replaces when-block dispatch on interface types with a registry of factory implementations keyed by interface type. Each factory owns:
- Eager validation of interface config (validate returns Result<Unit>)
- Construction of the corresponding adapter (create)
- Protocol defaults (previously inline at the consumer call site)

Adds DigitalAdapterRegistry / PhysicalAdapterRegistry with validateAll that aggregates all config errors across configured interfaces before any adapter is built.

New files:
- factory/digital/DigitalAdapterFactory.kt (interface)
- factory/digital/DigitalAdapterRegistry.kt
- factory/digital/MqttDigitalAdapterFactory.kt
- factory/digital/HttpDigitalAdapterFactory.kt
- factory/physical/PhysicalAdapterFactory.kt (interface)
- factory/physical/PhysicalAdapterRegistry.kt
- factory/physical/MqttPhysicalAdapterFactory.kt

Modified:
- HumanDigitalTwinFactory.kt — refactored to use registries; removed getDaFromDigitalInterfaceMqtt, getDaFromHttpDigitalInterface, getPaFromPhysicalInterfaceMqtt free functions
- build.gradle.kts — added Kotest test dependencies

Tests added for each factory (validate/create) and each registry (lookup hit/miss, single-error and multi-error validateAll).