### PR TITLE
Split Property specification from observation in whdt-core

### DIFF
--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/Property.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/Property.kt
@@ -4,7 +4,6 @@ import io.github.whdt.core.hdt.HdtIdFactory
 import io.github.whdt.core.hdt.model.ModelId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.time.Instant
 
 @JvmInline @Serializable value class PropertyId(val value: String) {
     override fun toString(): String = value
@@ -29,9 +28,17 @@ data class Property(
     val modelId: ModelId,
     val name: PropertyName,
     val description: PropertyDescription,
-    val timestamp: Instant,
-    val value: PropertyValue,
+    val declaredType: PropertyValueType,
+    val initialValue: PropertyValue? = null,
     val metadata: Map<String, String> = emptyMap(),
 ) {
     val id: PropertyId = HdtIdFactory.propertyId(modelId, name)
+
+    init {
+        if (initialValue != null) {
+            require(initialValue.valueType() == declaredType) {
+                "Property '$id': initialValue type ${initialValue.valueType()} does not match declaredType $declaredType"
+            }
+        }
+    }
 }

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/PropertyObservation.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/PropertyObservation.kt
@@ -1,0 +1,53 @@
+package io.github.whdt.core.hdt.model.property
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.ModelName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+@Serializable
+@SerialName("property-observation")
+data class PropertyObservation(
+    val hdtId: HdtId,
+    val modelId: ModelId,
+    val modelName: ModelName,
+    val propertyId: PropertyId,
+    val propertyName: PropertyName,
+    val timestamp: Instant,
+    val value: PropertyValue,
+    val metadata: Map<String, String> = emptyMap(),
+) {
+    init {
+        require(modelId == HdtIdFactory.modelId(hdtId, modelName)) {
+            "PropertyObservation: modelId '$modelId' inconsistent with (hdtId='$hdtId', modelName='$modelName')"
+        }
+        require(propertyId == HdtIdFactory.propertyId(modelId, propertyName)) {
+            "PropertyObservation: propertyId '$propertyId' inconsistent with (modelId='$modelId', propertyName='$propertyName')"
+        }
+    }
+
+    companion object {
+        fun of(
+            hdt: HumanDigitalTwin,
+            model: Model,
+            property: Property,
+            timestamp: Instant,
+            value: PropertyValue,
+            metadata: Map<String, String> = emptyMap(),
+        ): PropertyObservation = PropertyObservation(
+            hdtId = hdt.hdtId,
+            modelId = model.id,
+            modelName = model.name,
+            propertyId = property.id,
+            propertyName = property.name,
+            timestamp = timestamp,
+            value = value,
+            metadata = metadata,
+        )
+    }
+}

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/PropertyValueType.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/PropertyValueType.kt
@@ -1,0 +1,28 @@
+package io.github.whdt.core.hdt.model.property
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class PropertyValueType {
+    EMPTY, STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN;
+
+    fun defaultFor(): PropertyValue = when (this) {
+        EMPTY   -> PropertyValue.EmptyPropertyValue
+        STRING  -> PropertyValue.StringPropertyValue("")
+        INT     -> PropertyValue.IntPropertyValue(0)
+        LONG    -> PropertyValue.LongPropertyValue(0L)
+        FLOAT   -> PropertyValue.FloatPropertyValue(0f)
+        DOUBLE  -> PropertyValue.DoublePropertyValue(0.0)
+        BOOLEAN -> PropertyValue.BooleanPropertyValue(false)
+    }
+}
+
+fun PropertyValue.valueType(): PropertyValueType = when (this) {
+    is PropertyValue.EmptyPropertyValue   -> PropertyValueType.EMPTY
+    is PropertyValue.StringPropertyValue  -> PropertyValueType.STRING
+    is PropertyValue.IntPropertyValue     -> PropertyValueType.INT
+    is PropertyValue.LongPropertyValue    -> PropertyValueType.LONG
+    is PropertyValue.FloatPropertyValue   -> PropertyValueType.FLOAT
+    is PropertyValue.DoublePropertyValue  -> PropertyValueType.DOUBLE
+    is PropertyValue.BooleanPropertyValue -> PropertyValueType.BOOLEAN
+}

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/HdtIdFactoryTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/HdtIdFactoryTest.kt
@@ -13,7 +13,7 @@ import io.github.whdt.core.hdt.model.ModelName
 import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
-import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.core.hdt.storage.Storage
 import io.github.whdt.core.hdt.storage.StorageName
 import io.github.whdt.core.hdt.storage.StorageType
@@ -21,7 +21,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import kotlin.time.Clock
 
 class HdtIdFactoryTest : FunSpec({
 
@@ -33,8 +32,7 @@ class HdtIdFactoryTest : FunSpec({
         modelId = mId,
         name = PropertyName(name),
         description = PropertyDescription(""),
-        timestamp = Clock.System.now(),
-        value = PropertyValue.StringPropertyValue("x"),
+        declaredType = PropertyValueType.STRING,
     )
 
     fun buildModel(

--- a/whdt-distributed/src/main/kotlin/io/github/whdt/distributed/serde/Stub.kt
+++ b/whdt-distributed/src/main/kotlin/io/github/whdt/distributed/serde/Stub.kt
@@ -5,6 +5,7 @@ import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.model.Model
 import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyObservation
 import io.github.whdt.distributed.serde.modules.hdtModule
 import io.github.whdt.distributed.serde.modules.interfaceModule
 import io.github.whdt.distributed.serde.modules.propertyModule
@@ -39,6 +40,7 @@ object Stub {
     
     fun hdtJsonSerDe(): SerDe<HumanDigitalTwin> = jsonSerDe<HumanDigitalTwin>(hdtJson)
     fun propertyJsonSerDe(): SerDe<Property> = jsonSerDe<Property>(propertyJson)
+    fun observationJsonSerDe(): SerDe<PropertyObservation> = jsonSerDe<PropertyObservation>(propertyJson)
     fun modelJsonSerDe(): SerDe<Model> = jsonSerDe<Model>(propertyJson)
     fun physicalInterfaceJsonSerDe(): SerDe<PhysicalInterface> = jsonSerDe<PhysicalInterface>(interfaceJson)
     fun digitalInterfaceJsonSerDe(): SerDe<DigitalInterface> = jsonSerDe<DigitalInterface>(interfaceJson)

--- a/whdt-distributed/src/test/kotlin/serde/TestPropertyRefactor.kt
+++ b/whdt-distributed/src/test/kotlin/serde/TestPropertyRefactor.kt
@@ -1,0 +1,183 @@
+package serde
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyObservation
+import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.core.hdt.model.property.PropertyValueType
+import io.github.whdt.core.hdt.model.property.valueType
+import io.github.whdt.distributed.serde.Stub
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+class TestPropertyRefactor : FunSpec({
+
+    context("PropertyValueType.defaultFor()") {
+        test("EMPTY returns EmptyPropertyValue") {
+            PropertyValueType.EMPTY.defaultFor().shouldBeInstanceOf<PropertyValue.EmptyPropertyValue>()
+        }
+        test("STRING returns StringPropertyValue with empty string") {
+            PropertyValueType.STRING.defaultFor().shouldBeInstanceOf<PropertyValue.StringPropertyValue>().value shouldBe ""
+        }
+        test("INT returns IntPropertyValue with 0") {
+            PropertyValueType.INT.defaultFor().shouldBeInstanceOf<PropertyValue.IntPropertyValue>().value shouldBe 0
+        }
+        test("LONG returns LongPropertyValue with 0L") {
+            PropertyValueType.LONG.defaultFor().shouldBeInstanceOf<PropertyValue.LongPropertyValue>().value shouldBe 0L
+        }
+        test("FLOAT returns FloatPropertyValue with 0f") {
+            PropertyValueType.FLOAT.defaultFor().shouldBeInstanceOf<PropertyValue.FloatPropertyValue>().value shouldBe 0f
+        }
+        test("DOUBLE returns DoublePropertyValue with 0.0") {
+            PropertyValueType.DOUBLE.defaultFor().shouldBeInstanceOf<PropertyValue.DoublePropertyValue>().value shouldBe 0.0
+        }
+        test("BOOLEAN returns BooleanPropertyValue with false") {
+            PropertyValueType.BOOLEAN.defaultFor().shouldBeInstanceOf<PropertyValue.BooleanPropertyValue>().value shouldBe false
+        }
+    }
+
+    context("PropertyValue.valueType()") {
+        test("EmptyPropertyValue -> EMPTY") {
+            PropertyValue.EmptyPropertyValue.valueType() shouldBe PropertyValueType.EMPTY
+        }
+        test("StringPropertyValue -> STRING") {
+            PropertyValue.StringPropertyValue("x").valueType() shouldBe PropertyValueType.STRING
+        }
+        test("IntPropertyValue -> INT") {
+            PropertyValue.IntPropertyValue(1).valueType() shouldBe PropertyValueType.INT
+        }
+        test("LongPropertyValue -> LONG") {
+            PropertyValue.LongPropertyValue(1L).valueType() shouldBe PropertyValueType.LONG
+        }
+        test("FloatPropertyValue -> FLOAT") {
+            PropertyValue.FloatPropertyValue(1f).valueType() shouldBe PropertyValueType.FLOAT
+        }
+        test("DoublePropertyValue -> DOUBLE") {
+            PropertyValue.DoublePropertyValue(1.0).valueType() shouldBe PropertyValueType.DOUBLE
+        }
+        test("BooleanPropertyValue -> BOOLEAN") {
+            PropertyValue.BooleanPropertyValue(true).valueType() shouldBe PropertyValueType.BOOLEAN
+        }
+        test("defaultFor round-trip: every type") {
+            PropertyValueType.entries.forEach { type ->
+                type.defaultFor().valueType() shouldBe type
+            }
+        }
+    }
+
+    context("Property.init validation") {
+        val modelId = HdtIdFactory.modelId(HdtId("dt-1"), ModelName("model-1"))
+
+        test("null initialValue always succeeds") {
+            Property(
+                modelId = modelId,
+                name = PropertyName("prop"),
+                description = PropertyDescription(""),
+                declaredType = PropertyValueType.STRING,
+                initialValue = null,
+            )
+        }
+
+        test("matching initialValue type succeeds") {
+            Property(
+                modelId = modelId,
+                name = PropertyName("prop"),
+                description = PropertyDescription(""),
+                declaredType = PropertyValueType.STRING,
+                initialValue = PropertyValue.StringPropertyValue("hello"),
+            )
+        }
+
+        test("mismatched initialValue type throws IllegalArgumentException") {
+            shouldThrow<IllegalArgumentException> {
+                Property(
+                    modelId = modelId,
+                    name = PropertyName("prop"),
+                    description = PropertyDescription(""),
+                    declaredType = PropertyValueType.INT,
+                    initialValue = PropertyValue.StringPropertyValue("wrong-type"),
+                )
+            }
+        }
+    }
+
+    context("PropertyObservation SerDe round-trip") {
+        test("serializes and deserializes a PropertyObservation correctly") {
+            val hdtId = HdtId("dt-1")
+            val modelName = ModelName("my-model")
+            val modelId = HdtIdFactory.modelId(hdtId, modelName)
+            val propertyName = PropertyName("heart-rate")
+            val propertyId = HdtIdFactory.propertyId(modelId, propertyName)
+            val observation = PropertyObservation(
+                hdtId = hdtId,
+                modelId = modelId,
+                modelName = modelName,
+                propertyId = propertyId,
+                propertyName = propertyName,
+                timestamp = Clock.System.now(),
+                value = PropertyValue.IntPropertyValue(72),
+            )
+            val serde = Stub.observationJsonSerDe()
+            val serialized = serde.serialize(observation)
+            val deserialized = serde.deserialize(serialized)
+            deserialized shouldBe observation
+        }
+    }
+
+    context("PropertyObservation.init consistency checks") {
+        val hdtId = HdtId("dt-1")
+        val modelName = ModelName("my-model")
+        val modelId = HdtIdFactory.modelId(hdtId, modelName)
+        val propertyName = PropertyName("heart-rate")
+        val propertyId = HdtIdFactory.propertyId(modelId, propertyName)
+
+        test("rejects inconsistent modelId") {
+            shouldThrow<IllegalArgumentException> {
+                PropertyObservation(
+                    hdtId = hdtId,
+                    modelId = HdtIdFactory.modelId(HdtId("other"), ModelName("other-model")),
+                    modelName = modelName,
+                    propertyId = propertyId,
+                    propertyName = propertyName,
+                    timestamp = Clock.System.now(),
+                    value = PropertyValue.IntPropertyValue(0),
+                )
+            }
+        }
+
+        test("rejects inconsistent propertyId") {
+            shouldThrow<IllegalArgumentException> {
+                PropertyObservation(
+                    hdtId = hdtId,
+                    modelId = modelId,
+                    modelName = modelName,
+                    propertyId = HdtIdFactory.propertyId(modelId, PropertyName("other-prop")),
+                    propertyName = propertyName,
+                    timestamp = Clock.System.now(),
+                    value = PropertyValue.IntPropertyValue(0),
+                )
+            }
+        }
+
+        test("consistent observation constructs successfully") {
+            PropertyObservation(
+                hdtId = hdtId,
+                modelId = modelId,
+                modelName = modelName,
+                propertyId = propertyId,
+                propertyName = propertyName,
+                timestamp = Clock.System.now(),
+                value = PropertyValue.IntPropertyValue(72),
+            )
+        }
+    }
+})

--- a/whdt-distributed/src/test/kotlin/serde/TestSerDeHdt.kt
+++ b/whdt-distributed/src/test/kotlin/serde/TestSerDeHdt.kt
@@ -20,10 +20,10 @@ import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
 import io.github.whdt.core.hdt.model.property.PropertyValue
 import io.github.whdt.core.hdt.model.property.PropertyValue.Companion.pv
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.distributed.serde.Stub
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlin.time.Clock
 
 class TestSerDeHdt: FunSpec({
   test("Test SerDe HumanDigitalTwin") {
@@ -31,8 +31,8 @@ class TestSerDeHdt: FunSpec({
       val modelName = ModelName("my-model")
       val modelId = ModelId("$hdtId:$modelName")
       val properties = listOf(
-          testProperty(modelId, PropertyName("First Name"), "John".pv()),
-          testProperty(modelId, PropertyName("Surname"), "Doe".pv())
+          testProperty(modelId, PropertyName("First Name"), PropertyValueType.STRING, "John".pv()),
+          testProperty(modelId, PropertyName("Surname"), PropertyValueType.STRING, "Doe".pv())
       )
       val model = Model(hdtId, modelName, ModelDescription("Test Model"), properties)
       val pI = PhysicalInterface(
@@ -67,13 +67,13 @@ class TestSerDeHdt: FunSpec({
   }
 }) {
     companion object {
-        fun testProperty(modelId: ModelId, name: PropertyName, value: PropertyValue): Property {
+        fun testProperty(modelId: ModelId, name: PropertyName, declaredType: PropertyValueType, initialValue: PropertyValue? = null): Property {
             return Property(
                 modelId = modelId,
                 name = name,
                 description = PropertyDescription(""),
-                timestamp = Clock.System.now(),
-                value = value
+                declaredType = declaredType,
+                initialValue = initialValue,
             )
         }
     }

--- a/whdt-distributed/src/test/kotlin/serde/TestSerDeMessage.kt
+++ b/whdt-distributed/src/test/kotlin/serde/TestSerDeMessage.kt
@@ -6,6 +6,7 @@ import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
 import io.github.whdt.core.hdt.model.property.PropertyValue.Companion.pv
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.distributed.id.SenderId
 import io.github.whdt.distributed.message.Message
 import io.github.whdt.distributed.serde.Stub
@@ -29,8 +30,8 @@ class TestSerDeMessage: FunSpec({
           ModelId("my-model"),
           PropertyName("my-property"),
           PropertyDescription(""),
-          now,
-          "test-property".pv()
+          PropertyValueType.STRING,
+          "test-property".pv(),
       )
       val message = Message(
           hdt = hdtId,

--- a/whdt-distributed/src/test/kotlin/serde/TestSerDeProperty.kt
+++ b/whdt-distributed/src/test/kotlin/serde/TestSerDeProperty.kt
@@ -11,11 +11,10 @@ import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
 import io.github.whdt.core.hdt.model.property.PropertyValue
 import io.github.whdt.core.hdt.model.property.PropertyValue.Companion.pv
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.distributed.serde.Stub
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlin.time.Clock
-import kotlin.time.Instant
 
 class TestSerDeProperty: FunSpec({
     test("Test SerDe GenericProperty") {
@@ -25,11 +24,10 @@ class TestSerDeProperty: FunSpec({
             modelId,
             name = PropertyName("username"),
             description = PropertyDescription("The username of the user."),
-            timestamp = Clock.System.now(),
-            value = PropertyValue.StringPropertyValue("leona"),
+            declaredType = PropertyValueType.STRING,
+            initialValue = PropertyValue.StringPropertyValue("leona"),
         )
         val serialized = serde.serialize(prop)
-        //println(serialized)
         val deserialized = serde.deserialize(serialized)
 
         deserialized shouldBe prop
@@ -37,7 +35,6 @@ class TestSerDeProperty: FunSpec({
 
     test("Test SerDe Model") {
         val serde = Stub.modelJsonSerDe()
-        val now = Clock.System.now()
         val hdtId = HdtId("dt-1")
         val modelName = ModelName("my-model")
         val modelId = HdtIdFactory.modelId(hdtId, modelName)
@@ -46,24 +43,23 @@ class TestSerDeProperty: FunSpec({
             modelName,
             ModelDescription("Test Model"),
             listOf(
-                buildProperty(modelId, "username", now, "leona".pv()),
-                buildProperty(modelId, "password", now, "123456".pv()),
+                buildProperty(modelId, "username", PropertyValueType.STRING, "leona".pv()),
+                buildProperty(modelId, "password", PropertyValueType.STRING, "123456".pv()),
             )
         )
         val serialized = serde.serialize(model)
-        //println(serialized)
         val deserialized = serde.deserialize(serialized)
 
         deserialized shouldBe model
     }
 })
 
-fun buildProperty(modelId: ModelId, name: String, timestamp: Instant, value: PropertyValue): Property {
+fun buildProperty(modelId: ModelId, name: String, declaredType: PropertyValueType, initialValue: PropertyValue? = null): Property {
     return Property(
         modelId,
         PropertyName(name),
         PropertyDescription(""),
-        timestamp,
-        value
+        declaredType,
+        initialValue,
     )
 }

--- a/whdt-examples/src/main/kotlin/Main.kt
+++ b/whdt-examples/src/main/kotlin/Main.kt
@@ -16,15 +16,15 @@ import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
 import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.wldt.plugin.execution.WldtApp
-import kotlin.time.Clock
 
 fun main() {
     val hdtId = HdtId("Mimosa_1")
     val modelId = ModelId("$hdtId:my-model")
     val properties = listOf(
-        testProperty(modelId, "First Name", PropertyValue.StringPropertyValue("John")),
-        testProperty(modelId, "Surname", PropertyValue.StringPropertyValue("Doe"))
+        testProperty(modelId, "First Name", PropertyValueType.STRING, PropertyValue.StringPropertyValue("John")),
+        testProperty(modelId, "Surname", PropertyValueType.STRING, PropertyValue.StringPropertyValue("Doe"))
     )
     val model = Model(hdtId, ModelName("my-model"), ModelDescription("Test Model"), properties)
 
@@ -59,12 +59,12 @@ fun main() {
     println("Started Dts: ${startedDts.map { it.getOrNull() }}")
 }
 
-fun testProperty(modelId: ModelId, name: String, value: PropertyValue): Property {
+fun testProperty(modelId: ModelId, name: String, declaredType: PropertyValueType, initialValue: PropertyValue? = null): Property {
     return Property(
         modelId = modelId,
         name = PropertyName(name),
         description = PropertyDescription(""),
-        timestamp = Clock.System.now(),
-        value = value
+        declaredType = declaredType,
+        initialValue = initialValue,
     )
 }

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/HumanDigitalTwinFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/HumanDigitalTwinFactory.kt
@@ -15,18 +15,18 @@ import java.util.logging.Logger
 
 object HumanDigitalTwinFactory {
     val logger: Logger = Logger.getLogger("HumanDigitalTwinFactory")
-    val propertySerDe = Stub.propertyJsonSerDe()
+    val observationSerDe = Stub.observationJsonSerDe()
 
     private val digitalRegistry = DigitalAdapterRegistry(
         listOf(
-            MqttDigitalAdapterFactory(propertySerDe),
+            MqttDigitalAdapterFactory(observationSerDe),
             HttpDigitalAdapterFactory(),
         )
     )
 
     private val physicalRegistry = PhysicalAdapterRegistry(
         listOf(
-            MqttPhysicalAdapterFactory(propertySerDe),
+            MqttPhysicalAdapterFactory(observationSerDe),
         )
     )
 
@@ -34,17 +34,15 @@ object HumanDigitalTwinFactory {
         val shad = WhdtShadowingFunction("${hdt.hdtId}-shadowing-function", hdt.models)
         val dt = DigitalTwin(hdt.hdtId.id, shad)
 
-        val properties = hdt.models.flatMap { it.properties }
-
         physicalRegistry.validateAll(hdt.physicalInterfaces).getOrThrow()
         hdt.physicalInterfaces.forEach { pI ->
-            physicalRegistry.create(pI, properties)?.let { dt.addPhysicalAdapter(it) }
+            physicalRegistry.create(pI, hdt.models)?.let { dt.addPhysicalAdapter(it) }
                 ?: logger.warning("no factory registered for interface type ${pI.interfaceType}")
         }
 
         digitalRegistry.validateAll(hdt.digitalInterfaces).getOrThrow()
         hdt.digitalInterfaces.forEach { dI ->
-            digitalRegistry.create(dI, dt, properties)?.let { dt.addDigitalAdapter(it) }
+            digitalRegistry.create(dI, dt, hdt.models)?.let { dt.addDigitalAdapter(it) }
                 ?: logger.warning("no factory registered for interface type ${dI.interfaceType}")
         }
 

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterFactory.kt
@@ -2,7 +2,7 @@ package io.github.whdt.wldt.plugin.factory.digital
 
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import it.wldt.adapter.digital.DigitalAdapter
 import it.wldt.core.engine.DigitalTwin
 
@@ -19,5 +19,5 @@ interface DigitalAdapterFactory {
     /**
      * Constructs the adapter. Caller must validate first; create() may throw on bad config.
      */
-    fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*>
+    fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): DigitalAdapter<*>
 }

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistry.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistry.kt
@@ -2,7 +2,7 @@ package io.github.whdt.wldt.plugin.factory.digital
 
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import it.wldt.adapter.digital.DigitalAdapter
 import it.wldt.core.engine.DigitalTwin
 
@@ -32,6 +32,6 @@ class DigitalAdapterRegistry(factories: List<DigitalAdapterFactory>) {
         )
     }
 
-    fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*>? =
-        byType[dI.interfaceType]?.create(dI, dt, properties)
+    fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): DigitalAdapter<*>? =
+        byType[dI.interfaceType]?.create(dI, dt, models)
 }

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactory.kt
@@ -2,7 +2,7 @@ package io.github.whdt.wldt.plugin.factory.digital
 
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter
 import it.wldt.adapter.http.digital.adapter.HttpDigitalAdapterConfiguration
 import it.wldt.core.engine.DigitalTwin
@@ -15,11 +15,11 @@ class HttpDigitalAdapterFactory : DigitalAdapterFactory {
         dI.optionalInt("port", DEFAULT_PORT)
     }
 
-    override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): HttpDigitalAdapter {
+    override fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): HttpDigitalAdapter {
         val host = dI.optionalString("host", DEFAULT_HOST)
         val port = dI.optionalInt("port", DEFAULT_PORT)
         val httpConfig = HttpDigitalAdapterConfiguration(dI.id.toString(), host, port)
-        httpConfig.addPropertiesFilter(properties.map { it.id.toString() })
+        httpConfig.addPropertiesFilter(models.flatMap { it.properties }.map { it.id.toString() })
         return HttpDigitalAdapter(httpConfig, dt)
     }
 

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactory.kt
@@ -2,17 +2,20 @@ package io.github.whdt.wldt.plugin.factory.digital
 
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.property.PropertyObservation
+import io.github.whdt.core.hdt.model.property.PropertyValue
 import io.github.whdt.distributed.namespace.Namespace
 import io.github.whdt.distributed.serde.SerDe
 import it.wldt.adapter.mqtt.digital.MqttDigitalAdapter
 import it.wldt.adapter.mqtt.digital.MqttDigitalAdapterConfiguration
 import it.wldt.adapter.mqtt.digital.topic.MqttQosLevel
 import it.wldt.core.engine.DigitalTwin
+import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class MqttDigitalAdapterFactory(
-    private val propertySerDe: SerDe<Property>,
+    private val observationSerDe: SerDe<PropertyObservation>,
 ) : DigitalAdapterFactory {
     override val interfaceType = DigitalInterfaceType.MQTT
 
@@ -22,16 +25,33 @@ class MqttDigitalAdapterFactory(
     }
 
     @OptIn(ExperimentalTime::class)
-    override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): MqttDigitalAdapter {
+    override fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): MqttDigitalAdapter {
         val broker = dI.optionalString("broker", DEFAULT_BROKER)
         val port = dI.optionalInt("port", DEFAULT_PORT)
         val builder = MqttDigitalAdapterConfiguration.builder(broker, port)
-        properties.forEach { property ->
-            builder.addPropertyTopic(
-                property.id.toString(),
-                Namespace.propertyUpdateNotificationTopic(dI.hdtId, property.name),
-                MqttQosLevel.MQTT_QOS_0
-            ) { p: Property -> propertySerDe.serialize(p) }
+        val hdtId = dI.hdtId
+        models.forEach { model ->
+            model.properties.forEach { property ->
+                val capturedModel = model
+                val capturedProperty = property
+                builder.addPropertyTopic(
+                    property.id.toString(),
+                    Namespace.propertyUpdateNotificationTopic(hdtId, property.name),
+                    MqttQosLevel.MQTT_QOS_0
+                ) { value: Any? ->
+                    observationSerDe.serialize(
+                        PropertyObservation(
+                            hdtId = hdtId,
+                            modelId = capturedModel.id,
+                            modelName = capturedModel.name,
+                            propertyId = capturedProperty.id,
+                            propertyName = capturedProperty.name,
+                            timestamp = Clock.System.now(),
+                            value = value as PropertyValue,
+                        )
+                    )
+                }
+            }
         }
         return MqttDigitalAdapter(dI.id.toString(), builder.build())
     }

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactory.kt
@@ -2,14 +2,15 @@ package io.github.whdt.wldt.plugin.factory.physical
 
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.property.PropertyObservation
 import io.github.whdt.distributed.namespace.Namespace
 import io.github.whdt.distributed.serde.SerDe
 import it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter
 import it.wldt.adapter.mqtt.physical.MqttPhysicalAdapterConfiguration
 
 class MqttPhysicalAdapterFactory(
-    private val propertySerDe: SerDe<Property>,
+    private val observationSerDe: SerDe<PropertyObservation>,
 ) : PhysicalAdapterFactory {
     override val interfaceType = PhysicalInterfaceType.MQTT
 
@@ -18,17 +19,17 @@ class MqttPhysicalAdapterFactory(
         pI.optionalInt("port", DEFAULT_PORT)
     }
 
-    override fun create(pI: PhysicalInterface, properties: List<Property>): MqttPhysicalAdapter {
+    override fun create(pI: PhysicalInterface, models: List<Model>): MqttPhysicalAdapter {
         val broker = pI.optionalString("broker", DEFAULT_BROKER)
         val port = pI.optionalInt("port", DEFAULT_PORT)
         val builder = MqttPhysicalAdapterConfiguration.builder(broker, port)
-        properties.forEach { property ->
+        models.flatMap { it.properties }.forEach { property ->
             builder.addPhysicalAssetPropertyAndTopic(
                 property.id.toString(),
-                property,
+                property.initialValue ?: property.declaredType.defaultFor(),
                 Namespace.propertyUpdateRequestTopic(pI.hdtId, property.name)
             ) { string ->
-                propertySerDe.deserialize(string)
+                observationSerDe.deserialize(string).value
             }
         }
         return MqttPhysicalAdapter(pI.id.toString(), builder.build())

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterFactory.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterFactory.kt
@@ -2,7 +2,7 @@ package io.github.whdt.wldt.plugin.factory.physical
 
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import it.wldt.adapter.physical.PhysicalAdapter
 
 interface PhysicalAdapterFactory {
@@ -18,5 +18,5 @@ interface PhysicalAdapterFactory {
     /**
      * Constructs the adapter. Caller must validate first; create() may throw on bad config.
      */
-    fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter
+    fun create(pI: PhysicalInterface, models: List<Model>): PhysicalAdapter
 }

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistry.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistry.kt
@@ -2,7 +2,7 @@ package io.github.whdt.wldt.plugin.factory.physical
 
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import it.wldt.adapter.physical.PhysicalAdapter
 
 class PhysicalAdapterRegistry(factories: List<PhysicalAdapterFactory>) {
@@ -31,6 +31,6 @@ class PhysicalAdapterRegistry(factories: List<PhysicalAdapterFactory>) {
         )
     }
 
-    fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter? =
-        byType[pI.interfaceType]?.create(pI, properties)
+    fun create(pI: PhysicalInterface, models: List<Model>): PhysicalAdapter? =
+        byType[pI.interfaceType]?.create(pI, models)
 }

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/DigitalAdapterRegistryTest.kt
@@ -4,7 +4,7 @@ import io.github.whdt.core.hdt.HdtId
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
@@ -31,7 +31,7 @@ class DigitalAdapterRegistryTest : FunSpec({
     val alwaysOkFactory = object : DigitalAdapterFactory {
         override val interfaceType = DigitalInterfaceType.MQTT
         override fun validate(dI: DigitalInterface): Result<Unit> = Result.success(Unit)
-        override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> =
+        override fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): DigitalAdapter<*> =
             error("not used in registry tests")
     }
 
@@ -39,7 +39,7 @@ class DigitalAdapterRegistryTest : FunSpec({
         override val interfaceType = DigitalInterfaceType.HTTP
         override fun validate(dI: DigitalInterface): Result<Unit> =
             Result.failure(IllegalArgumentException("bad config for ${dI.id}"))
-        override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> =
+        override fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): DigitalAdapter<*> =
             error("not used in registry tests")
     }
 
@@ -80,7 +80,7 @@ class DigitalAdapterRegistryTest : FunSpec({
                 override val interfaceType = DigitalInterfaceType.MQTT
                 override fun validate(dI: DigitalInterface): Result<Unit> =
                     Result.failure(IllegalArgumentException("mqtt fail for ${dI.id}"))
-                override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> =
+                override fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): DigitalAdapter<*> =
                     error("not used")
             }
             val registry = DigitalAdapterRegistry(listOf(anotherFailFactory, alwaysFailFactory))
@@ -112,12 +112,11 @@ class DigitalAdapterRegistryTest : FunSpec({
         }
 
         test("delegates to the matching factory") {
-            val sentinel = object {}
             val capturingFactory = object : DigitalAdapterFactory {
                 var called = false
                 override val interfaceType = DigitalInterfaceType.MQTT
                 override fun validate(dI: DigitalInterface): Result<Unit> = Result.success(Unit)
-                override fun create(dI: DigitalInterface, dt: DigitalTwin, properties: List<Property>): DigitalAdapter<*> {
+                override fun create(dI: DigitalInterface, dt: DigitalTwin, models: List<Model>): DigitalAdapter<*> {
                     called = true
                     error("sentinel — not a real adapter") // won't reach assertion check
                 }

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/HttpDigitalAdapterFactoryTest.kt
@@ -1,22 +1,23 @@
 package io.github.whdt.wldt.plugin.factory.digital
 
 import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelDescription
+import io.github.whdt.core.hdt.model.ModelName
 import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
-import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 class HttpDigitalAdapterFactoryTest : FunSpec({
 
@@ -56,12 +57,12 @@ class HttpDigitalAdapterFactoryTest : FunSpec({
         test("returns an HttpDigitalAdapter") {
             val dI = di()
             val dt = mockDigitalTwin()
-            val adapter = factory.create(dI, dt, listOf(testProperty()))
+            val adapter = factory.create(dI, dt, listOf(testModel()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
         }
 
         test("applies default host and port when config is empty") {
-            val adapter = factory.create(di(), mockDigitalTwin(), listOf(testProperty()))
+            val adapter = factory.create(di(), mockDigitalTwin(), listOf(testModel()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
         }
 
@@ -69,7 +70,7 @@ class HttpDigitalAdapterFactoryTest : FunSpec({
             val adapter = factory.create(
                 di(mapOf("host" to "custom.host", "port" to "9090")),
                 mockDigitalTwin(),
-                listOf(testProperty()),
+                listOf(testModel()),
             )
             adapter.shouldBeInstanceOf<it.wldt.adapter.http.digital.adapter.HttpDigitalAdapter>()
         }
@@ -81,11 +82,20 @@ private fun mockDigitalTwin() = it.wldt.core.engine.DigitalTwin(
     io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
 )
 
-@OptIn(ExperimentalTime::class)
-private fun testProperty() = Property(
-    modelId = ModelId("test-model"),
-    name = PropertyName("test-prop"),
-    description = PropertyDescription(""),
-    timestamp = Clock.System.now(),
-    value = PropertyValue.StringPropertyValue("value"),
-)
+private fun testModel(): Model {
+    val hdtId = HdtId("test-hdt")
+    val modelName = ModelName("test-model")
+    return Model(
+        hdtId = hdtId,
+        name = modelName,
+        description = ModelDescription(""),
+        properties = listOf(
+            Property(
+                modelId = HdtIdFactory.modelId(hdtId, modelName),
+                name = PropertyName("test-prop"),
+                description = PropertyDescription(""),
+                declaredType = PropertyValueType.STRING,
+            )
+        ),
+    )
+}

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/digital/MqttDigitalAdapterFactoryTest.kt
@@ -1,14 +1,17 @@
 package io.github.whdt.wldt.plugin.factory.digital
 
 import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceName
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterfaceType
-import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelDescription
+import io.github.whdt.core.hdt.model.ModelName
 import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
-import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.distributed.serde.Stub
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
@@ -16,12 +19,10 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 class MqttDigitalAdapterFactoryTest : FunSpec({
 
-    val factory = MqttDigitalAdapterFactory(Stub.propertyJsonSerDe())
+    val factory = MqttDigitalAdapterFactory(Stub.observationJsonSerDe())
 
     fun di(config: Map<String, String> = emptyMap()) = DigitalInterface(
         interfaceType = DigitalInterfaceType.MQTT,
@@ -60,13 +61,13 @@ class MqttDigitalAdapterFactoryTest : FunSpec({
     context("create") {
         test("returns a MqttDigitalAdapter with the correct id") {
             val dI = di()
-            val adapter = factory.create(dI, mockDigitalTwin(), listOf(testProperty()))
+            val adapter = factory.create(dI, mockDigitalTwin(), listOf(testModel()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
             adapter.id shouldBe dI.id.toString()
         }
 
         test("applies default broker and port when config is empty") {
-            val adapter = factory.create(di(), mockDigitalTwin(), listOf(testProperty()))
+            val adapter = factory.create(di(), mockDigitalTwin(), listOf(testModel()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
         }
 
@@ -74,7 +75,7 @@ class MqttDigitalAdapterFactoryTest : FunSpec({
             val adapter = factory.create(
                 di(mapOf("broker" to "custom.broker", "port" to "1884")),
                 mockDigitalTwin(),
-                listOf(testProperty()),
+                listOf(testModel()),
             )
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.digital.MqttDigitalAdapter>()
         }
@@ -86,11 +87,20 @@ private fun mockDigitalTwin() = it.wldt.core.engine.DigitalTwin(
     io.github.whdt.wldt.plugin.shadowing.WhdtShadowingFunction("mock-sf", emptyList()),
 )
 
-@OptIn(ExperimentalTime::class)
-private fun testProperty() = Property(
-    modelId = ModelId("test-model"),
-    name = PropertyName("test-prop"),
-    description = PropertyDescription(""),
-    timestamp = Clock.System.now(),
-    value = PropertyValue.StringPropertyValue("value"),
-)
+private fun testModel(): Model {
+    val hdtId = HdtId("test-hdt")
+    val modelName = ModelName("test-model")
+    return Model(
+        hdtId = hdtId,
+        name = modelName,
+        description = ModelDescription(""),
+        properties = listOf(
+            Property(
+                modelId = HdtIdFactory.modelId(hdtId, modelName),
+                name = PropertyName("test-prop"),
+                description = PropertyDescription(""),
+                declaredType = PropertyValueType.STRING,
+            )
+        ),
+    )
+}

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactoryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/MqttPhysicalAdapterFactoryTest.kt
@@ -4,11 +4,13 @@ import io.github.whdt.core.hdt.HdtId
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceName
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
-import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelDescription
+import io.github.whdt.core.hdt.model.ModelName
 import io.github.whdt.core.hdt.model.property.Property
 import io.github.whdt.core.hdt.model.property.PropertyDescription
 import io.github.whdt.core.hdt.model.property.PropertyName
-import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.core.hdt.model.property.PropertyValueType
 import io.github.whdt.distributed.serde.Stub
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
@@ -16,12 +18,10 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 class MqttPhysicalAdapterFactoryTest : FunSpec({
 
-    val factory = MqttPhysicalAdapterFactory(Stub.propertyJsonSerDe())
+    val factory = MqttPhysicalAdapterFactory(Stub.observationJsonSerDe())
 
     fun pi(config: Map<String, String> = emptyMap()) = PhysicalInterface(
         interfaceType = PhysicalInterfaceType.MQTT,
@@ -56,31 +56,41 @@ class MqttPhysicalAdapterFactoryTest : FunSpec({
     context("create") {
         test("returns a MqttPhysicalAdapter with the correct id") {
             val pI = pi()
-            val adapter = factory.create(pI, listOf(testProperty()))
+            val adapter = factory.create(pI, listOf(testModel()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
             adapter.id shouldBe pI.id.toString()
         }
 
         test("applies default broker and port when config is empty") {
-            val adapter = factory.create(pi(), listOf(testProperty()))
+            val adapter = factory.create(pi(), listOf(testModel()))
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
         }
 
         test("uses provided broker and port from config") {
             val adapter = factory.create(
                 pi(mapOf("broker" to "custom.broker", "port" to "1884")),
-                listOf(testProperty()),
+                listOf(testModel()),
             )
             adapter.shouldBeInstanceOf<it.wldt.adapter.mqtt.physical.MqttPhysicalAdapter>()
         }
     }
 })
 
-@OptIn(ExperimentalTime::class)
-private fun testProperty() = Property(
-    modelId = ModelId("test-model"),
-    name = PropertyName("test-prop"),
-    description = PropertyDescription(""),
-    timestamp = Clock.System.now(),
-    value = PropertyValue.StringPropertyValue("value"),
-)
+private fun testModel(): Model {
+    val hdtId = HdtId("test-hdt")
+    val modelName = ModelName("test-model")
+    val model = Model(
+        hdtId = hdtId,
+        name = modelName,
+        description = ModelDescription(""),
+        properties = listOf(
+            Property(
+                modelId = io.github.whdt.core.hdt.HdtIdFactory.modelId(hdtId, modelName),
+                name = PropertyName("test-prop"),
+                description = PropertyDescription(""),
+                declaredType = PropertyValueType.STRING,
+            )
+        ),
+    )
+    return model
+}

--- a/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistryTest.kt
+++ b/whdt-wldt-plugin/src/test/kotlin/io/github/whdt/wldt/plugin/factory/physical/PhysicalAdapterRegistryTest.kt
@@ -4,7 +4,7 @@ import io.github.whdt.core.hdt.HdtId
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceName
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterfaceType
-import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.Model
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.result.shouldBeFailure
@@ -28,7 +28,7 @@ class PhysicalAdapterRegistryTest : FunSpec({
     val alwaysOkFactory = object : PhysicalAdapterFactory {
         override val interfaceType = PhysicalInterfaceType.MQTT
         override fun validate(pI: PhysicalInterface): Result<Unit> = Result.success(Unit)
-        override fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter =
+        override fun create(pI: PhysicalInterface, models: List<Model>): PhysicalAdapter =
             error("not used in registry tests")
     }
 
@@ -36,7 +36,7 @@ class PhysicalAdapterRegistryTest : FunSpec({
         override val interfaceType = PhysicalInterfaceType.MQTT
         override fun validate(pI: PhysicalInterface): Result<Unit> =
             Result.failure(IllegalArgumentException("bad config for ${pI.id}"))
-        override fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter =
+        override fun create(pI: PhysicalInterface, models: List<Model>): PhysicalAdapter =
             error("not used in registry tests")
     }
 
@@ -90,7 +90,7 @@ class PhysicalAdapterRegistryTest : FunSpec({
                 var called = false
                 override val interfaceType = PhysicalInterfaceType.MQTT
                 override fun validate(pI: PhysicalInterface): Result<Unit> = Result.success(Unit)
-                override fun create(pI: PhysicalInterface, properties: List<Property>): PhysicalAdapter {
+                override fun create(pI: PhysicalInterface, models: List<Model>): PhysicalAdapter {
                     called = true
                     error("sentinel — not a real adapter")
                 }


### PR DESCRIPTION
## Summary

### Files created and modified

**whdt-core**
- Created: `property/PropertyValueType.kt` — enum with `defaultFor()`, `valueType()` extension
- Created: `property/PropertyObservation.kt` — wire/storage type with init consistency checks and `of()` factory
- Modified: `property/Property.kt` — removed `timestamp`/`value`, added `declaredType` and optional `initialValue` with type-match `init` validation
- Modified: `HdtIdFactoryTest.kt` — updated `prop()` helper to new Property shape

**whdt-distributed**
- Modified: `serde/Stub.kt` — added `observationJsonSerDe()` (reuses `propertyJson` which already has PropertyValue polymorphic module)
- Modified: `TestSerDeHdt.kt`, `TestSerDeProperty.kt`, `TestSerDeMessage.kt` — updated `Property` construction
- Created: `TestPropertyRefactor.kt` — new tests for `defaultFor()`, `valueType()`, `Property.init`, `PropertyObservation` SerDe and init

**whdt-wldt-plugin**
- Modified: `DigitalAdapterFactory`, `PhysicalAdapterFactory` interfaces — `create()` now takes `List<Model>` instead of `List<Property>`
- Modified: `DigitalAdapterRegistry`, `PhysicalAdapterRegistry` — propagate signature change
- Modified: `MqttPhysicalAdapterFactory` — uses `observationSerDe`; seeds WLDT with `property.initialValue ?: property.declaredType.defaultFor()`; deserialize callback returns `observationSerDe.deserialize(string).value`
- Modified: `MqttDigitalAdapterFactory` — uses `observationSerDe`; serialize callback captures `hdtId`/`model`/`property` at construction time and builds `PropertyObservation(...)`
- Modified: `HttpDigitalAdapterFactory` — updated `create()` signature
- Modified: `HumanDigitalTwinFactory` — uses `observationSerDe`; passes `hdt.models` to registries
- Modified: all 5 factory tests — updated to new signatures and `Property` shape

**whdt-examples**
- Modified: `Main.kt` — updated `testProperty()` to use `declaredType`/`initialValue`

### WLDT API signatures used

**Physical adapter seeding:**
`addPhysicalAssetPropertyAndTopic(property.id.toString(), property.initialValue ?: property.declaredType.defaultFor(), topic) { string -> observationSerDe.deserialize(string).value }`

**Digital adapter serialize callback:**
Closure captures `hdtId: HdtId` (from `dI.hdtId`), `capturedModel: Model`, `capturedProperty: Property` at construction. When called:
`observationSerDe.serialize(PropertyObservation(hdtId=.., modelId=capturedModel.id, modelName=capturedModel.name, propertyId=capturedProperty.id, propertyName=capturedProperty.name, timestamp=Clock.System.now(), value=value as PropertyValue))`

### SerializersModule changes

No new module registration was needed. `PropertyObservation.value` is a `PropertyValue` sealed class field handled by the existing `propertyModule`. `Stub.observationJsonSerDe()` reuses `propertyJson` which already has the polymorphic module and `classDiscriminator = "type"`.

### Deviations from spec

1. Factory `create()` interfaces changed to take `List<Model>` instead of `List<Property>` — required to supply model name context (`ModelName`) to the MQTT digital adapter for building `PropertyObservation` in the closure.
2. `PropertyObservation` is constructed directly in `MqttDigitalAdapterFactory` rather than via `PropertyObservation.of()` — the factory doesn’t have a `HumanDigitalTwin` at closure time, only the individual context fields. The `of()` helper on the companion object is available for callers that do have the full `HumanDigitalTwin`.

### persistence-service impact

`persistence-service` is unaffected by this change — it is a separate repository that is not part of this module tree. Any required updates to consume `PropertyObservation` should be tracked in a separate follow-up issue.

Generated with [Claude Code](https://claude.ai/code)