### PR TITLE
feat: add tag-based query layer (TagPredicate ADT, DSL, PropertyQuery)

### DIFF
--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/PropertyQuery.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/PropertyQuery.kt
@@ -1,0 +1,41 @@
+package io.github.whdt.core.hdt.query
+
+import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.property.Property
+
+/**
+ * Returns the properties whose [Property.tags] satisfy [predicate].
+ * Preserves the input list order.
+ */
+fun List<Property>.filterByTags(predicate: TagPredicate): List<Property> =
+    filter { predicate.matches(it.tags) }
+
+/**
+ * Groups by the value of tag [key]. Properties missing the key are placed under
+ * the `null` bucket. Result is a [LinkedHashMap]; group keys appear in the order
+ * they were first encountered while scanning the input.
+ */
+fun List<Property>.groupByTag(key: String): Map<String?, List<Property>> {
+    val result = LinkedHashMap<String?, MutableList<Property>>()
+    for (p in this) {
+        val v: String? = p.tags[key]
+        result.getOrPut(v) { mutableListOf() } += p
+    }
+    return result
+}
+
+/**
+ * Hierarchical grouping. Applies [groupByTag] to each bucket of an existing
+ * group result. Both levels preserve insertion order; both can have a `null`
+ * bucket independently.
+ */
+fun Map<String?, List<Property>>.thenGroupByTag(key: String): Map<String?, Map<String?, List<Property>>> =
+    mapValues { (_, props) -> props.groupByTag(key) }
+
+/**
+ * Flat view of every Property declared across every Model of [this] HDT,
+ * preserving Model order and intra-Model property order. Each Property
+ * retains its `modelId`, so consumers can recover provenance after filtering.
+ */
+fun HumanDigitalTwin.allProperties(): List<Property> =
+    models.flatMap { it.properties }

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/TagPredicate.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/TagPredicate.kt
@@ -1,0 +1,46 @@
+package io.github.whdt.core.hdt.query
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Boolean algebra over a `Map<String, String>` of tags. Reified as data so it
+ * can be serialized, persisted, and later compiled to a backend query
+ * (a named View stores a [TagPredicate] verbatim).
+ *
+ * Operates exclusively on [io.github.whdt.core.hdt.model.property.Property.tags];
+ * does not see `coding`, `format`, or any other Property field.
+ *
+ * Identity laws:
+ *  - `And(emptyList())` evaluates to `true`  (vacuous conjunction).
+ *  - `Or(emptyList())`  evaluates to `false` (vacuous disjunction).
+ */
+@Serializable
+sealed interface TagPredicate {
+    @Serializable @SerialName("eq")
+    data class Eq(val key: String, val value: String) : TagPredicate
+
+    @Serializable @SerialName("in")
+    data class In(val key: String, val values: Set<String>) : TagPredicate
+
+    @Serializable @SerialName("has")
+    data class Has(val key: String) : TagPredicate
+
+    @Serializable @SerialName("and")
+    data class And(val terms: List<TagPredicate>) : TagPredicate
+
+    @Serializable @SerialName("or")
+    data class Or(val terms: List<TagPredicate>) : TagPredicate
+
+    @Serializable @SerialName("not")
+    data class Not(val term: TagPredicate) : TagPredicate
+}
+
+fun TagPredicate.matches(tags: Map<String, String>): Boolean = when (this) {
+    is TagPredicate.Eq  -> tags[key] == value
+    is TagPredicate.In  -> tags[key] in values
+    is TagPredicate.Has -> key in tags
+    is TagPredicate.And -> terms.all { it.matches(tags) }
+    is TagPredicate.Or  -> terms.any { it.matches(tags) }
+    is TagPredicate.Not -> !term.matches(tags)
+}

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/TagPredicateDsl.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/TagPredicateDsl.kt
@@ -1,0 +1,18 @@
+package io.github.whdt.core.hdt.query
+
+/** Builder DSL for [TagPredicate]. Prefix functions only in this iteration. */
+
+fun eq(key: String, value: String): TagPredicate = TagPredicate.Eq(key, value)
+
+fun inSet(key: String, values: Set<String>): TagPredicate = TagPredicate.In(key, values)
+fun inSet(key: String, vararg values: String): TagPredicate = TagPredicate.In(key, values.toSet())
+
+fun has(key: String): TagPredicate = TagPredicate.Has(key)
+
+fun and(vararg terms: TagPredicate): TagPredicate = TagPredicate.And(terms.toList())
+fun and(terms: List<TagPredicate>): TagPredicate  = TagPredicate.And(terms)
+
+fun or(vararg terms: TagPredicate): TagPredicate = TagPredicate.Or(terms.toList())
+fun or(terms: List<TagPredicate>): TagPredicate  = TagPredicate.Or(terms)
+
+fun not(term: TagPredicate): TagPredicate = TagPredicate.Not(term)

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/PropertyQueryTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/PropertyQueryTest.kt
@@ -1,0 +1,282 @@
+package io.github.whdt.core.hdt.query
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelDescription
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValueType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+class PropertyQueryTest : FunSpec({
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    val hdtId = HdtId("test-hdt")
+
+    fun modelId(name: String): ModelId = HdtIdFactory.modelId(hdtId, ModelName(name))
+
+    fun prop(name: String, modelId: ModelId, tags: Map<String, String> = emptyMap()) = Property(
+        modelId = modelId,
+        name = PropertyName(name),
+        description = PropertyDescription(""),
+        declaredType = PropertyValueType.STRING,
+        tags = tags,
+    )
+
+    fun model(name: String, props: List<Property>): Model {
+        val mId = modelId(name)
+        return Model(
+            hdtId = hdtId,
+            name = ModelName(name),
+            description = ModelDescription(""),
+            properties = props,
+        )
+    }
+
+    fun hdt(vararg models: Model) = HumanDigitalTwin(hdtId = hdtId, models = models.toList())
+
+    // -------------------------------------------------------------------------
+    // filterByTags
+    // -------------------------------------------------------------------------
+
+    context("filterByTags") {
+        val mId = modelId("m")
+
+        test("empty input returns empty list") {
+            emptyList<Property>().filterByTags(eq("domain", "motor")) shouldBe emptyList()
+        }
+
+        test("no matches returns empty list") {
+            val props = listOf(prop("p1", mId, mapOf("domain" to "sensor")))
+            props.filterByTags(eq("domain", "motor")) shouldBe emptyList()
+        }
+
+        test("single matching property is returned") {
+            val p = prop("p1", mId, mapOf("domain" to "motor"))
+            listOf(p).filterByTags(eq("domain", "motor")) shouldBe listOf(p)
+        }
+
+        test("all matching properties are returned") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, mapOf("domain" to "motor"))
+            listOf(p1, p2).filterByTags(eq("domain", "motor")) shouldBe listOf(p1, p2)
+        }
+
+        test("preserves input order") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor", "task" to "grasp"))
+            val p2 = prop("p2", mId, mapOf("domain" to "sensor"))
+            val p3 = prop("p3", mId, mapOf("domain" to "motor", "task" to "push"))
+            val result = listOf(p1, p2, p3).filterByTags(has("task"))
+            result shouldBe listOf(p1, p3)
+        }
+
+        test("leaves non-matching items out") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, mapOf("domain" to "sensor"))
+            val result = listOf(p1, p2).filterByTags(eq("domain", "motor"))
+            result shouldContainExactly listOf(p1)
+        }
+
+        test("accepts predicates built via DSL") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor", "task" to "grasp"))
+            val p2 = prop("p2", mId, mapOf("domain" to "motor"))
+            val p3 = prop("p3", mId, mapOf("domain" to "sensor"))
+            val result = listOf(p1, p2, p3).filterByTags(and(eq("domain", "motor"), has("task")))
+            result shouldBe listOf(p1)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // groupByTag
+    // -------------------------------------------------------------------------
+
+    context("groupByTag") {
+        val mId = modelId("m")
+
+        test("empty input returns empty map") {
+            emptyList<Property>().groupByTag("domain").shouldBeEmpty()
+        }
+
+        test("properties with the key are bucketed by value") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, mapOf("domain" to "sensor"))
+            val result = listOf(p1, p2).groupByTag("domain")
+            result["motor"] shouldBe listOf(p1)
+            result["sensor"] shouldBe listOf(p2)
+        }
+
+        test("properties without the key go to the null bucket") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, emptyMap())
+            val result = listOf(p1, p2).groupByTag("domain")
+            result[null] shouldBe listOf(p2)
+        }
+
+        test("group keys appear in first-encounter (insertion) order") {
+            val p1 = prop("p1", mId, mapOf("domain" to "sensor"))
+            val p2 = prop("p2", mId, mapOf("domain" to "motor"))
+            val p3 = prop("p3", mId, mapOf("domain" to "sensor"))
+            val result = listOf(p1, p2, p3).groupByTag("domain")
+            result.keys.toList() shouldBe listOf("sensor", "motor")
+        }
+
+        test("properties within each bucket preserve input order") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, mapOf("domain" to "motor"))
+            val p3 = prop("p3", mId, mapOf("domain" to "motor"))
+            val result = listOf(p1, p2, p3).groupByTag("domain")
+            result["motor"] shouldBe listOf(p1, p2, p3)
+        }
+
+        test("null bucket and named buckets can coexist") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, emptyMap())
+            val result = listOf(p1, p2).groupByTag("domain")
+            result.keys.toList() shouldBe listOf("motor", null)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // thenGroupByTag
+    // -------------------------------------------------------------------------
+
+    context("thenGroupByTag") {
+        val mId = modelId("m")
+
+        test("produces Map<String?, Map<String?, List<Property>>>") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor", "task" to "grasp"))
+            val result = listOf(p1).groupByTag("domain").thenGroupByTag("task")
+            result["motor"]?.get("grasp") shouldBe listOf(p1)
+        }
+
+        test("both levels preserve insertion order") {
+            val p1 = prop("p1", mId, mapOf("domain" to "sensor", "task" to "read"))
+            val p2 = prop("p2", mId, mapOf("domain" to "motor", "task" to "grasp"))
+            val p3 = prop("p3", mId, mapOf("domain" to "sensor", "task" to "write"))
+            val result = listOf(p1, p2, p3).groupByTag("domain").thenGroupByTag("task")
+            result.keys.toList() shouldBe listOf("sensor", "motor")
+            result["sensor"]?.keys?.toList() shouldBe listOf("read", "write")
+        }
+
+        test("both levels can independently have a null bucket") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor"))
+            val p2 = prop("p2", mId, emptyMap())
+            val result = listOf(p1, p2).groupByTag("domain").thenGroupByTag("task")
+            result["motor"]?.get(null) shouldBe listOf(p1)
+            result[null]?.get(null) shouldBe listOf(p2)
+        }
+
+        test("chaining produces correct inner grouping") {
+            val p1 = prop("p1", mId, mapOf("domain" to "motor", "task" to "grasp"))
+            val p2 = prop("p2", mId, mapOf("domain" to "motor", "task" to "push"))
+            val p3 = prop("p3", mId, mapOf("domain" to "sensor"))
+            val result = listOf(p1, p2, p3).groupByTag("domain").thenGroupByTag("task")
+            result["motor"]?.keys?.toList() shouldBe listOf("grasp", "push")
+            result["sensor"]?.get(null) shouldBe listOf(p3)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // HumanDigitalTwin.allProperties()
+    // -------------------------------------------------------------------------
+
+    context("HumanDigitalTwin.allProperties()") {
+
+        test("empty HDT returns empty list") {
+            hdt().allProperties() shouldBe emptyList()
+        }
+
+        test("single-model HDT returns its properties") {
+            val mId = modelId("vitals")
+            val p1 = prop("heart-rate", mId)
+            val p2 = prop("spo2", mId)
+            val result = hdt(model("vitals", listOf(p1, p2))).allProperties()
+            result shouldBe listOf(p1, p2)
+        }
+
+        test("multi-model HDT flattens in model order") {
+            val mId1 = modelId("vitals")
+            val mId2 = modelId("activity")
+            val p1 = prop("heart-rate", mId1)
+            val p2 = prop("spo2", mId1)
+            val p3 = prop("steps", mId2)
+            val result = hdt(model("vitals", listOf(p1, p2)), model("activity", listOf(p3))).allProperties()
+            result shouldBe listOf(p1, p2, p3)
+        }
+
+        test("each property retains its modelId") {
+            val mId1 = modelId("vitals")
+            val mId2 = modelId("activity")
+            val p1 = prop("heart-rate", mId1)
+            val p2 = prop("steps", mId2)
+            val allProps = hdt(model("vitals", listOf(p1)), model("activity", listOf(p2))).allProperties()
+            allProps[0].modelId shouldBe mId1
+            allProps[1].modelId shouldBe mId2
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration test — preterm-neuropathology scenario (step 10)
+    // -------------------------------------------------------------------------
+
+    context("Integration — motor+task filter with groupByTag") {
+        val motorMId  = modelId("motor")
+        val sensorMId = modelId("sensor")
+
+        val grasp    = prop("grasp-force",     motorMId,  mapOf("domain" to "motor",  "task"  to "grasp",  "visit" to "v1"))
+        val push     = prop("push-torque",     motorMId,  mapOf("domain" to "motor",  "task"  to "push",   "visit" to "v1"))
+        val emg      = prop("emg-amplitude",   motorMId,  mapOf("domain" to "motor",  "task"  to "grasp",  "visit" to "v2"))
+        val eeg      = prop("eeg-band-power",  sensorMId, mapOf("domain" to "sensor", "visit" to "v1"))
+        val heartRate = prop("heart-rate",     sensorMId, mapOf("domain" to "sensor", "task"  to "rest"))
+        val steps    = prop("step-count",      sensorMId, mapOf("domain" to "sensor"))
+
+        val testHdt  = hdt(
+            model("motor",  listOf(grasp, push, emg)),
+            model("sensor", listOf(eeg, heartRate, steps)),
+        )
+
+        test("allProperties flattens 6 properties in model order") {
+            testHdt.allProperties() shouldBe listOf(grasp, push, emg, eeg, heartRate, steps)
+        }
+
+        test("filterByTags(and(eq(domain,motor), has(task))) keeps only motor+task props") {
+            val result = testHdt.allProperties()
+                .filterByTags(and(eq("domain", "motor"), has("task")))
+            result shouldBe listOf(grasp, push, emg)
+        }
+
+        test("groupByTag(task) on motor+task props produces expected structure") {
+            val grouped = testHdt.allProperties()
+                .filterByTags(and(eq("domain", "motor"), has("task")))
+                .groupByTag("task")
+            grouped["grasp"] shouldBe listOf(grasp, emg)
+            grouped["push"]  shouldBe listOf(push)
+        }
+
+        test("groupByTag(domain).thenGroupByTag(task) produces two-level hierarchy") {
+            val result = testHdt.allProperties()
+                .groupByTag("domain")
+                .thenGroupByTag("task")
+            result["motor"]?.keys?.toList()  shouldBe listOf("grasp", "push")
+            result["sensor"]?.keys?.toList() shouldBe listOf(null, "rest")
+        }
+
+        test("thenGroupByTag sensor null bucket contains steps") {
+            val result = testHdt.allProperties()
+                .groupByTag("domain")
+                .thenGroupByTag("task")
+            result["sensor"]?.get(null) shouldBe listOf(eeg, steps)
+        }
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/TagPredicateDslTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/TagPredicateDslTest.kt
@@ -1,0 +1,79 @@
+package io.github.whdt.core.hdt.query
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TagPredicateDslTest : FunSpec({
+
+    context("DSL builders — produce expected ADT shapes") {
+
+        test("eq produces Eq") {
+            eq("domain", "motor") shouldBe TagPredicate.Eq("domain", "motor")
+        }
+
+        test("inSet vararg produces In with a set") {
+            inSet("env", "prod", "staging") shouldBe TagPredicate.In("env", setOf("prod", "staging"))
+        }
+
+        test("inSet Set overload produces In") {
+            inSet("env", setOf("prod", "staging")) shouldBe TagPredicate.In("env", setOf("prod", "staging"))
+        }
+
+        test("inSet vararg and Set overload produce equivalent results") {
+            val vararg = inSet("k", "a", "b", "c")
+            val set    = inSet("k", setOf("a", "b", "c"))
+            vararg shouldBe set
+        }
+
+        test("has produces Has") {
+            has("task") shouldBe TagPredicate.Has("task")
+        }
+
+        test("not wraps a predicate in Not") {
+            not(has("task")) shouldBe TagPredicate.Not(TagPredicate.Has("task"))
+        }
+
+        test("and vararg produces And") {
+            and(eq("a", "b"), has("c")) shouldBe
+                TagPredicate.And(listOf(TagPredicate.Eq("a", "b"), TagPredicate.Has("c")))
+        }
+
+        test("and List overload produces And") {
+            and(listOf(eq("a", "b"), has("c"))) shouldBe
+                TagPredicate.And(listOf(TagPredicate.Eq("a", "b"), TagPredicate.Has("c")))
+        }
+
+        test("and vararg and List overload produce equivalent results") {
+            val vararg = and(eq("x", "1"), has("y"))
+            val list   = and(listOf(eq("x", "1"), has("y")))
+            vararg shouldBe list
+        }
+
+        test("or vararg produces Or") {
+            or(eq("a", "b"), has("c")) shouldBe
+                TagPredicate.Or(listOf(TagPredicate.Eq("a", "b"), TagPredicate.Has("c")))
+        }
+
+        test("or List overload produces Or") {
+            or(listOf(eq("a", "b"), has("c"))) shouldBe
+                TagPredicate.Or(listOf(TagPredicate.Eq("a", "b"), TagPredicate.Has("c")))
+        }
+
+        test("or vararg and List overload produce equivalent results") {
+            val vararg = or(eq("x", "1"), has("y"))
+            val list   = or(listOf(eq("x", "1"), has("y")))
+            vararg shouldBe list
+        }
+
+        test("DSL functions compose into nested structures") {
+            val pred = and(eq("domain", "motor"), or(has("task"), not(eq("env", "prod"))))
+            pred shouldBe TagPredicate.And(listOf(
+                TagPredicate.Eq("domain", "motor"),
+                TagPredicate.Or(listOf(
+                    TagPredicate.Has("task"),
+                    TagPredicate.Not(TagPredicate.Eq("env", "prod")),
+                )),
+            ))
+        }
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/TagPredicateSerializationTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/TagPredicateSerializationTest.kt
@@ -1,0 +1,99 @@
+package io.github.whdt.core.hdt.query
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class TagPredicateSerializationTest : FunSpec({
+
+    val json = Json {
+        classDiscriminator = "type"
+        encodeDefaults = true
+    }
+
+    fun roundTrip(predicate: TagPredicate): TagPredicate {
+        val encoded = json.encodeToString(TagPredicate.serializer(), predicate)
+        return json.decodeFromString(TagPredicate.serializer(), encoded)
+    }
+
+    context("JSON round-trip — leaf variants") {
+
+        test("Eq round-trips") {
+            val p = TagPredicate.Eq("domain", "motor")
+            roundTrip(p) shouldBe p
+        }
+
+        test("In round-trips with multiple values") {
+            val p = TagPredicate.In("env", setOf("prod", "staging", "dev"))
+            roundTrip(p) shouldBe p
+        }
+
+        test("Has round-trips") {
+            val p = TagPredicate.Has("task")
+            roundTrip(p) shouldBe p
+        }
+
+        test("And with empty list round-trips") {
+            val p = TagPredicate.And(emptyList())
+            roundTrip(p) shouldBe p
+        }
+
+        test("Or with empty list round-trips") {
+            val p = TagPredicate.Or(emptyList())
+            roundTrip(p) shouldBe p
+        }
+
+        test("Not round-trips") {
+            val p = TagPredicate.Not(TagPredicate.Has("missing"))
+            roundTrip(p) shouldBe p
+        }
+    }
+
+    context("JSON round-trip — nested composition") {
+
+        test("3-level nested And(Or(Not(...), Eq(...)), Has(...)) round-trips") {
+            val p = TagPredicate.And(listOf(
+                TagPredicate.Or(listOf(
+                    TagPredicate.Not(TagPredicate.Eq("env", "prod")),
+                    TagPredicate.Eq("domain", "motor"),
+                )),
+                TagPredicate.Has("task"),
+            ))
+            roundTrip(p) shouldBe p
+        }
+    }
+
+    context("JSON shape — type discriminator field") {
+
+        test("Eq encodes with type=eq") {
+            val encoded = json.encodeToString(TagPredicate.serializer(), TagPredicate.Eq("k", "v"))
+            (encoded.contains("\"type\"") && encoded.contains("\"eq\"")) shouldBe true
+        }
+
+        test("In encodes with type=in") {
+            val encoded = json.encodeToString(TagPredicate.serializer(), TagPredicate.In("k", setOf("v")))
+            (encoded.contains("\"type\"") && encoded.contains("\"in\"")) shouldBe true
+        }
+
+        test("Has encodes with type=has") {
+            val encoded = json.encodeToString(TagPredicate.serializer(), TagPredicate.Has("k"))
+            (encoded.contains("\"type\"") && encoded.contains("\"has\"")) shouldBe true
+        }
+
+        test("And encodes with type=and") {
+            val encoded = json.encodeToString(TagPredicate.serializer(), TagPredicate.And(emptyList()))
+            (encoded.contains("\"type\"") && encoded.contains("\"and\"")) shouldBe true
+        }
+
+        test("Or encodes with type=or") {
+            val encoded = json.encodeToString(TagPredicate.serializer(), TagPredicate.Or(emptyList()))
+            (encoded.contains("\"type\"") && encoded.contains("\"or\"")) shouldBe true
+        }
+
+        test("Not encodes with type=not") {
+            val encoded = json.encodeToString(TagPredicate.serializer(), TagPredicate.Not(TagPredicate.Has("k")))
+            (encoded.contains("\"type\"") && encoded.contains("\"not\"")) shouldBe true
+        }
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/TagPredicateTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/TagPredicateTest.kt
@@ -1,0 +1,172 @@
+package io.github.whdt.core.hdt.query
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TagPredicateTest : FunSpec({
+
+    // -------------------------------------------------------------------------
+    // Structural tests — variant construction and data-class equality
+    // -------------------------------------------------------------------------
+
+    context("TagPredicate variants — construction and structural equality") {
+
+        test("Eq constructs and compares by value") {
+            TagPredicate.Eq("domain", "motor") shouldBe TagPredicate.Eq("domain", "motor")
+        }
+
+        test("In constructs and compares by value") {
+            TagPredicate.In("env", setOf("prod", "staging")) shouldBe
+                TagPredicate.In("env", setOf("staging", "prod"))
+        }
+
+        test("Has constructs and compares by value") {
+            TagPredicate.Has("task") shouldBe TagPredicate.Has("task")
+        }
+
+        test("And constructs and compares by value") {
+            val a = TagPredicate.And(listOf(TagPredicate.Has("x"), TagPredicate.Has("y")))
+            val b = TagPredicate.And(listOf(TagPredicate.Has("x"), TagPredicate.Has("y")))
+            a shouldBe b
+        }
+
+        test("Or constructs and compares by value") {
+            val a = TagPredicate.Or(listOf(TagPredicate.Eq("k", "v")))
+            val b = TagPredicate.Or(listOf(TagPredicate.Eq("k", "v")))
+            a shouldBe b
+        }
+
+        test("Not constructs and compares by value") {
+            TagPredicate.Not(TagPredicate.Has("x")) shouldBe TagPredicate.Not(TagPredicate.Has("x"))
+        }
+
+        test("sealed when expression is exhaustive over all six variants") {
+            val variants: List<TagPredicate> = listOf(
+                TagPredicate.Eq("k", "v"),
+                TagPredicate.In("k", setOf("v")),
+                TagPredicate.Has("k"),
+                TagPredicate.And(emptyList()),
+                TagPredicate.Or(emptyList()),
+                TagPredicate.Not(TagPredicate.Has("k")),
+            )
+            val names = variants.map {
+                when (it) {
+                    is TagPredicate.Eq  -> "Eq"
+                    is TagPredicate.In  -> "In"
+                    is TagPredicate.Has -> "Has"
+                    is TagPredicate.And -> "And"
+                    is TagPredicate.Or  -> "Or"
+                    is TagPredicate.Not -> "Not"
+                }
+            }
+            names shouldBe listOf("Eq", "In", "Has", "And", "Or", "Not")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // matches() — leaf operators
+    // -------------------------------------------------------------------------
+
+    val fixture = mapOf("domain" to "motor", "task" to "grasp", "env" to "prod")
+
+    context("matches() — Eq") {
+        test("returns true when tag equals expected value") {
+            TagPredicate.Eq("domain", "motor").matches(fixture) shouldBe true
+        }
+
+        test("returns false when tag has a different value") {
+            TagPredicate.Eq("domain", "sensor").matches(fixture) shouldBe false
+        }
+
+        test("returns false when tag is absent") {
+            TagPredicate.Eq("missing", "x").matches(fixture) shouldBe false
+        }
+    }
+
+    context("matches() — In") {
+        test("returns true when tag value is in the set") {
+            TagPredicate.In("env", setOf("prod", "staging")).matches(fixture) shouldBe true
+        }
+
+        test("returns false when tag value is not in the set") {
+            TagPredicate.In("env", setOf("dev", "staging")).matches(fixture) shouldBe false
+        }
+
+        test("returns false when tag is absent") {
+            TagPredicate.In("missing", setOf("a", "b")).matches(fixture) shouldBe false
+        }
+    }
+
+    context("matches() — Has") {
+        test("returns true when the key exists") {
+            TagPredicate.Has("task").matches(fixture) shouldBe true
+        }
+
+        test("returns false when the key is absent") {
+            TagPredicate.Has("missing").matches(fixture) shouldBe false
+        }
+    }
+
+    context("matches() — Not") {
+        test("negates a true predicate to false") {
+            TagPredicate.Not(TagPredicate.Has("task")).matches(fixture) shouldBe false
+        }
+
+        test("negates a false predicate to true") {
+            TagPredicate.Not(TagPredicate.Has("missing")).matches(fixture) shouldBe true
+        }
+    }
+
+    context("matches() — And") {
+        test("true when all terms match") {
+            TagPredicate.And(listOf(
+                TagPredicate.Eq("domain", "motor"),
+                TagPredicate.Has("task"),
+            )).matches(fixture) shouldBe true
+        }
+
+        test("false when at least one term does not match") {
+            TagPredicate.And(listOf(
+                TagPredicate.Eq("domain", "motor"),
+                TagPredicate.Eq("task", "push"),
+            )).matches(fixture) shouldBe false
+        }
+
+        test("identity law: And(emptyList()) is true") {
+            TagPredicate.And(emptyList()).matches(emptyMap()) shouldBe true
+        }
+    }
+
+    context("matches() — Or") {
+        test("true when at least one term matches") {
+            TagPredicate.Or(listOf(
+                TagPredicate.Eq("domain", "sensor"),
+                TagPredicate.Has("task"),
+            )).matches(fixture) shouldBe true
+        }
+
+        test("false when no term matches") {
+            TagPredicate.Or(listOf(
+                TagPredicate.Eq("domain", "sensor"),
+                TagPredicate.Has("missing"),
+            )).matches(fixture) shouldBe false
+        }
+
+        test("identity law: Or(emptyList()) is false") {
+            TagPredicate.Or(emptyList()).matches(emptyMap()) shouldBe false
+        }
+    }
+
+    context("matches() — nested composition") {
+        test("and(eq, or(has, not(has))) evaluates correctly") {
+            val pred = TagPredicate.And(listOf(
+                TagPredicate.Eq("domain", "motor"),
+                TagPredicate.Or(listOf(
+                    TagPredicate.Has("missing"),
+                    TagPredicate.Not(TagPredicate.Has("missing")),
+                )),
+            ))
+            pred.matches(fixture) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
Implements the tag-based query layer as specified in Issue #62.

## Changes

### New source files
`whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/`
- `TagPredicate.kt` — sealed interface with 6 variants (Eq, In, Has, And, Or, Not), all @Serializable with @SerialName discriminators, plus matches() evaluator
- `TagPredicateDsl.kt` — prefix builder functions (eq, inSet, has, and, or, not)
- `PropertyQuery.kt` — filterByTags, groupByTag, thenGroupByTag, HumanDigitalTwin.allProperties()

### New test files
`whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/`
- `TagPredicateTest.kt` — 24 tests
- `TagPredicateSerializationTest.kt` — 13 tests
- `TagPredicateDslTest.kt` — 13 tests
- `PropertyQueryTest.kt` — 26 tests including integration

## Notes

Predicates are **tag-only** by design — no references to `coding`, `declaredType`, `format`, or any other non-tag field. Cross-Model lookup by `Coding` is a separate focused API in Issue #3.

No deviations from spec.

`./gradlew build` and `./gradlew test`: **BUILD SUCCESSFUL** across all modules.

Generated with [Claude Code](https://claude.ai/code)