### PR TITLE
feat: add Coding linkage events and query primitives (#64)

### DIFF
--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/event/CodingLinkedUpdateEvent.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/event/CodingLinkedUpdateEvent.kt
@@ -1,0 +1,36 @@
+package io.github.whdt.core.hdt.event
+
+import io.github.whdt.core.hdt.model.property.Coding
+import io.github.whdt.core.hdt.model.property.PropertyId
+import io.github.whdt.core.hdt.model.property.PropertyValue
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Emitted by the shadowing function when a Property carrying a [Coding]
+ * has a value variation AND at least one sibling Property in another Model
+ * shares the same [Coding]. The event surfaces the linkage; consumers decide
+ * what (if anything) to do with sibling properties.
+ *
+ * The framework does NOT auto-write [newValue] into the linked siblings.
+ *
+ * Wire format: serialized as JSON via kotlinx.serialization, passed as the
+ * String body of a [it.wldt.core.state.DigitalTwinStateEventNotification].
+ */
+@Serializable
+@SerialName("coding-linked-update")
+data class CodingLinkedUpdateEvent(
+    /** The Property whose value just changed. */
+    val sourcePropertyId: PropertyId,
+    /** The Coding the source Property carries. */
+    val coding: Coding,
+    /** Siblings sharing [coding] in OTHER Properties; excludes [sourcePropertyId]. Never empty (the event is suppressed otherwise). */
+    val linkedPropertyIds: List<PropertyId>,
+    /** The new value of the source Property. */
+    val newValue: PropertyValue,
+) {
+    companion object {
+        /** The WLDT event key registered by `WhdtShadowingFunction` and used by subscribers. */
+        const val WLDT_EVENT_KEY: String = "whdt.coding-linked-update"
+    }
+}

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/PropertyValue.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/model/property/PropertyValue.kt
@@ -39,3 +39,23 @@ sealed class PropertyValue {
         fun String.pv(): PropertyValue = StringPropertyValue(this)
     }
 }
+
+/**
+ * Maps a JVM value into a [PropertyValue].
+ * - `null` → [PropertyValue.EmptyPropertyValue]
+ * - `String`, `Int`, `Long`, `Float`, `Double`, `Boolean` → matching wrapper
+ * - anything else → `null`
+ *
+ * Top-level (not in [PropertyValue.Companion]) to avoid overload ambiguity
+ * with the primitive `.pv()` helpers and to signal that this conversion may fail.
+ */
+fun Any?.toPropertyValue(): PropertyValue? = when (this) {
+    null       -> PropertyValue.EmptyPropertyValue
+    is String  -> PropertyValue.StringPropertyValue(this)
+    is Int     -> PropertyValue.IntPropertyValue(this)
+    is Long    -> PropertyValue.LongPropertyValue(this)
+    is Float   -> PropertyValue.FloatPropertyValue(this)
+    is Double  -> PropertyValue.DoublePropertyValue(this)
+    is Boolean -> PropertyValue.BooleanPropertyValue(this)
+    else       -> null
+}

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/CodingQuery.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/CodingQuery.kt
@@ -1,0 +1,20 @@
+package io.github.whdt.core.hdt.query
+
+import io.github.whdt.core.hdt.model.property.Coding
+import io.github.whdt.core.hdt.model.property.Property
+
+/**
+ * Returns every Property whose [Property.coding] equals [coding]. Properties
+ * with `coding == null` are skipped. Result preserves input order.
+ */
+fun List<Property>.findByCoding(coding: Coding): List<Property> =
+    filter { it.coding == coding }
+
+/**
+ * Indexes Properties by their non-null [Property.coding]. Properties with
+ * `coding == null` are excluded entirely (they are not linkable). Two
+ * Properties sharing a Coding will be grouped together; this is the basis
+ * on which the shadowing function detects cross-Model linkage.
+ */
+fun List<Property>.propertiesByCoding(): Map<Coding, List<Property>> =
+    filter { it.coding != null }.groupBy { it.coding!! }

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/PropertyQuery.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/query/PropertyQuery.kt
@@ -1,6 +1,7 @@
 package io.github.whdt.core.hdt.query
 
 import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.property.Coding
 import io.github.whdt.core.hdt.model.property.Property
 
 /**
@@ -39,3 +40,9 @@ fun Map<String?, List<Property>>.thenGroupByTag(key: String): Map<String?, Map<S
  */
 fun HumanDigitalTwin.allProperties(): List<Property> =
     models.flatMap { it.properties }
+
+fun HumanDigitalTwin.findByCoding(coding: Coding): List<Property> =
+    allProperties().findByCoding(coding)
+
+fun HumanDigitalTwin.propertiesByCoding(): Map<Coding, List<Property>> =
+    allProperties().propertiesByCoding()

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/event/CodingLinkedUpdateEventTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/event/CodingLinkedUpdateEventTest.kt
@@ -1,0 +1,99 @@
+package io.github.whdt.core.hdt.event
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Coding
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CodingLinkedUpdateEventTest : FunSpec({
+
+    val testJson = Json {
+        serializersModule = SerializersModule {
+            polymorphic(PropertyValue::class) {
+                subclass(PropertyValue.EmptyPropertyValue::class, PropertyValue.EmptyPropertyValue.serializer())
+                subclass(PropertyValue.StringPropertyValue::class, PropertyValue.StringPropertyValue.serializer())
+                subclass(PropertyValue.IntPropertyValue::class, PropertyValue.IntPropertyValue.serializer())
+                subclass(PropertyValue.FloatPropertyValue::class, PropertyValue.FloatPropertyValue.serializer())
+                subclass(PropertyValue.BooleanPropertyValue::class, PropertyValue.BooleanPropertyValue.serializer())
+                subclass(PropertyValue.DoublePropertyValue::class, PropertyValue.DoublePropertyValue.serializer())
+                subclass(PropertyValue.LongPropertyValue::class, PropertyValue.LongPropertyValue.serializer())
+            }
+        }
+        classDiscriminator = "type"
+    }
+
+    val hdtId = HdtId("test-hdt")
+    val modelId1 = HdtIdFactory.modelId(hdtId, ModelName("raw"))
+    val modelId2 = HdtIdFactory.modelId(hdtId, ModelName("fhir"))
+    val sourceId = HdtIdFactory.propertyId(modelId1, PropertyName("systolic"))
+    val linkedId = HdtIdFactory.propertyId(modelId2, PropertyName("systolic-fhir"))
+    val coding = Coding("loinc", "8480-6")
+
+    fun roundTrip(event: CodingLinkedUpdateEvent): CodingLinkedUpdateEvent {
+        val json = testJson.encodeToString(CodingLinkedUpdateEvent.serializer(), event)
+        return testJson.decodeFromString(CodingLinkedUpdateEvent.serializer(), json)
+    }
+
+    test("WLDT_EVENT_KEY constant equals expected value") {
+        CodingLinkedUpdateEvent.WLDT_EVENT_KEY shouldBe "whdt.coding-linked-update"
+    }
+
+    test("data class structural equality") {
+        val e1 = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.IntPropertyValue(120))
+        val e2 = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.IntPropertyValue(120))
+        e1 shouldBe e2
+    }
+
+    test("JSON round-trip with IntPropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.IntPropertyValue(120))
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with StringPropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.StringPropertyValue("120 mmHg"))
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with LongPropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.LongPropertyValue(9876543210L))
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with FloatPropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.FloatPropertyValue(120.5f))
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with DoublePropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.DoublePropertyValue(120.567))
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with BooleanPropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.BooleanPropertyValue(true))
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with EmptyPropertyValue") {
+        val event = CodingLinkedUpdateEvent(sourceId, coding, listOf(linkedId), PropertyValue.EmptyPropertyValue)
+        roundTrip(event) shouldBe event
+    }
+
+    test("JSON round-trip with multiple linkedPropertyIds") {
+        val linkedId2 = HdtIdFactory.propertyId(
+            HdtIdFactory.modelId(hdtId, ModelName("hl7")),
+            PropertyName("bp-systolic"),
+        )
+        val event = CodingLinkedUpdateEvent(
+            sourceId, coding, listOf(linkedId, linkedId2), PropertyValue.IntPropertyValue(120)
+        )
+        roundTrip(event) shouldBe event
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/model/property/ToPropertyValueTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/model/property/ToPropertyValueTest.kt
@@ -1,0 +1,48 @@
+package io.github.whdt.core.hdt.model.property
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
+
+class ToPropertyValueTest : FunSpec({
+
+    test("null maps to EmptyPropertyValue") {
+        null.toPropertyValue() shouldBe PropertyValue.EmptyPropertyValue
+    }
+
+    test("String maps to StringPropertyValue") {
+        "hello".toPropertyValue() shouldBe PropertyValue.StringPropertyValue("hello")
+    }
+
+    test("Int maps to IntPropertyValue") {
+        42.toPropertyValue() shouldBe PropertyValue.IntPropertyValue(42)
+    }
+
+    test("Long maps to LongPropertyValue") {
+        100L.toPropertyValue() shouldBe PropertyValue.LongPropertyValue(100L)
+    }
+
+    test("Float maps to FloatPropertyValue") {
+        3.14f.toPropertyValue() shouldBe PropertyValue.FloatPropertyValue(3.14f)
+    }
+
+    test("Double maps to DoublePropertyValue") {
+        2.718.toPropertyValue() shouldBe PropertyValue.DoublePropertyValue(2.718)
+    }
+
+    test("Boolean true maps to BooleanPropertyValue") {
+        true.toPropertyValue() shouldBe PropertyValue.BooleanPropertyValue(true)
+    }
+
+    test("Boolean false maps to BooleanPropertyValue") {
+        false.toPropertyValue() shouldBe PropertyValue.BooleanPropertyValue(false)
+    }
+
+    test("unsupported type returns null") {
+        listOf(1, 2, 3).toPropertyValue().shouldBeNull()
+    }
+
+    test("another unsupported type returns null") {
+        mapOf("a" to 1).toPropertyValue().shouldBeNull()
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/CodingQueryTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/query/CodingQueryTest.kt
@@ -1,0 +1,150 @@
+package io.github.whdt.core.hdt.query
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelDescription
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Coding
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValueType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+class CodingQueryTest : FunSpec({
+
+    val hdtId = HdtId("test-hdt")
+    val coding1 = Coding("loinc", "8480-6")
+    val coding2 = Coding("snomed", "271649006")
+
+    fun modelId(name: String) = HdtIdFactory.modelId(hdtId, ModelName(name))
+
+    fun prop(name: String, modelName: String, coding: Coding? = null) = Property(
+        modelId = modelId(modelName),
+        name = PropertyName(name),
+        description = PropertyDescription(""),
+        declaredType = PropertyValueType.INT,
+        coding = coding,
+    )
+
+    fun model(name: String, props: List<Property>): Model = Model(
+        hdtId = hdtId,
+        name = ModelName(name),
+        description = ModelDescription(""),
+        properties = props,
+    )
+
+    fun hdt(vararg models: Model) = HumanDigitalTwin(hdtId = hdtId, models = models.toList())
+
+    // -------------------------------------------------------------------------
+    // List<Property>.findByCoding
+    // -------------------------------------------------------------------------
+
+    context("List<Property>.findByCoding") {
+        test("returns empty list when input is empty") {
+            emptyList<Property>().findByCoding(coding1).shouldBeEmpty()
+        }
+
+        test("returns matching properties") {
+            val p1 = prop("systolic", "raw", coding1)
+            val p2 = prop("systolic-fhir", "fhir", coding1)
+            val p3 = prop("other", "raw", coding2)
+            listOf(p1, p2, p3).findByCoding(coding1) shouldContainExactly listOf(p1, p2)
+        }
+
+        test("returns empty list when no properties match") {
+            val p1 = prop("other", "raw", coding2)
+            listOf(p1).findByCoding(coding1).shouldBeEmpty()
+        }
+
+        test("skips properties with null coding") {
+            val p1 = prop("no-coding", "raw", null)
+            listOf(p1).findByCoding(coding1).shouldBeEmpty()
+        }
+
+        test("preserves input order") {
+            val p1 = prop("a", "raw", coding1)
+            val p2 = prop("b", "fhir", coding1)
+            listOf(p2, p1).findByCoding(coding1) shouldContainExactly listOf(p2, p1)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // List<Property>.propertiesByCoding
+    // -------------------------------------------------------------------------
+
+    context("List<Property>.propertiesByCoding") {
+        test("returns empty map when input is empty") {
+            emptyList<Property>().propertiesByCoding().shouldBeEmpty()
+        }
+
+        test("excludes properties with null coding") {
+            val p1 = prop("no-coding", "raw", null)
+            listOf(p1).propertiesByCoding().shouldBeEmpty()
+        }
+
+        test("groups properties by coding") {
+            val p1 = prop("systolic", "raw", coding1)
+            val p2 = prop("systolic-fhir", "fhir", coding1)
+            val p3 = prop("diastolic", "raw", coding2)
+            val result = listOf(p1, p2, p3).propertiesByCoding()
+            result[coding1] shouldContainExactly listOf(p1, p2)
+            result[coding2] shouldContainExactly listOf(p3)
+        }
+
+        test("properties with null coding are absent from the map") {
+            val p1 = prop("coded", "raw", coding1)
+            val p2 = prop("uncoded", "raw", null)
+            val result = listOf(p1, p2).propertiesByCoding()
+            result.size shouldBe 1
+            result[coding1] shouldContainExactly listOf(p1)
+        }
+
+        test("two properties with the same coding grouped together") {
+            val p1 = prop("a", "model1", coding1)
+            val p2 = prop("b", "model2", coding1)
+            val result = listOf(p1, p2).propertiesByCoding()
+            result[coding1] shouldContainExactly listOf(p1, p2)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // HumanDigitalTwin.findByCoding / propertiesByCoding
+    // -------------------------------------------------------------------------
+
+    context("HumanDigitalTwin coding lookups") {
+        val p1 = prop("systolic", "raw", coding1)
+        val p2 = prop("systolic-fhir", "fhir", coding1)
+        val p3 = prop("no-coding", "raw", null)
+
+        val testHdt = hdt(
+            model("raw", listOf(p1, p3)),
+            model("fhir", listOf(p2)),
+        )
+
+        test("findByCoding returns both linked properties") {
+            testHdt.findByCoding(coding1) shouldContainExactly listOf(p1, p2)
+        }
+
+        test("findByCoding returns empty for unknown coding") {
+            testHdt.findByCoding(coding2).shouldBeEmpty()
+        }
+
+        test("propertiesByCoding groups linked properties") {
+            val result = testHdt.propertiesByCoding()
+            result[coding1]?.size shouldBe 2
+            result[coding1] shouldContainExactly listOf(p1, p2)
+        }
+
+        test("propertiesByCoding excludes properties without coding") {
+            val result = testHdt.propertiesByCoding()
+            result.values.flatten().none { it == p3 } shouldBe true
+        }
+    }
+})

--- a/whdt-distributed/src/main/kotlin/io/github/whdt/distributed/serde/Stub.kt
+++ b/whdt-distributed/src/main/kotlin/io/github/whdt/distributed/serde/Stub.kt
@@ -1,6 +1,7 @@
 package io.github.whdt.distributed.serde
 
 import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.event.CodingLinkedUpdateEvent
 import io.github.whdt.core.hdt.interfaces.digital.DigitalInterface
 import io.github.whdt.core.hdt.interfaces.physical.PhysicalInterface
 import io.github.whdt.core.hdt.model.Model
@@ -45,4 +46,5 @@ object Stub {
     fun physicalInterfaceJsonSerDe(): SerDe<PhysicalInterface> = jsonSerDe<PhysicalInterface>(interfaceJson)
     fun digitalInterfaceJsonSerDe(): SerDe<DigitalInterface> = jsonSerDe<DigitalInterface>(interfaceJson)
     fun messageJsonSerDe(): SerDe<Message> = jsonSerDe<Message>(messageJson)
+    fun codingLinkedUpdateEventSerDe(): SerDe<CodingLinkedUpdateEvent> = jsonSerDe<CodingLinkedUpdateEvent>(propertyJson)
 }

--- a/whdt-distributed/src/test/kotlin/serde/TestSerDeCodingLinkedUpdateEvent.kt
+++ b/whdt-distributed/src/test/kotlin/serde/TestSerDeCodingLinkedUpdateEvent.kt
@@ -1,0 +1,58 @@
+package serde
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.event.CodingLinkedUpdateEvent
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Coding
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValue
+import io.github.whdt.distributed.serde.Stub
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TestSerDeCodingLinkedUpdateEvent : FunSpec({
+
+    val serde = Stub.codingLinkedUpdateEventSerDe()
+
+    val hdtId = HdtId("patient-1")
+    val modelId1 = HdtIdFactory.modelId(hdtId, ModelName("raw"))
+    val modelId2 = HdtIdFactory.modelId(hdtId, ModelName("fhir"))
+    val sourceId = HdtIdFactory.propertyId(modelId1, PropertyName("systolic"))
+    val linkedId = HdtIdFactory.propertyId(modelId2, PropertyName("systolic-fhir"))
+    val coding = Coding("loinc", "8480-6")
+
+    test("round-trip with IntPropertyValue") {
+        val event = CodingLinkedUpdateEvent(
+            sourcePropertyId = sourceId,
+            coding = coding,
+            linkedPropertyIds = listOf(linkedId),
+            newValue = PropertyValue.IntPropertyValue(120),
+        )
+        serde.deserialize(serde.serialize(event)) shouldBe event
+    }
+
+    test("round-trip with StringPropertyValue") {
+        val event = CodingLinkedUpdateEvent(
+            sourcePropertyId = sourceId,
+            coding = coding,
+            linkedPropertyIds = listOf(linkedId),
+            newValue = PropertyValue.StringPropertyValue("120 mmHg"),
+        )
+        serde.deserialize(serde.serialize(event)) shouldBe event
+    }
+
+    test("round-trip with multiple linkedPropertyIds") {
+        val linkedId2 = HdtIdFactory.propertyId(
+            HdtIdFactory.modelId(hdtId, ModelName("hl7")),
+            PropertyName("bp-systolic"),
+        )
+        val event = CodingLinkedUpdateEvent(
+            sourcePropertyId = sourceId,
+            coding = coding,
+            linkedPropertyIds = listOf(linkedId, linkedId2),
+            newValue = PropertyValue.IntPropertyValue(120),
+        )
+        serde.deserialize(serde.serialize(event)) shouldBe event
+    }
+})

--- a/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/shadowing/WhdtShadowingFunction.kt
+++ b/whdt-wldt-plugin/src/main/kotlin/io/github/whdt/wldt/plugin/shadowing/WhdtShadowingFunction.kt
@@ -1,6 +1,12 @@
 package io.github.whdt.wldt.plugin.shadowing
 
+import io.github.whdt.core.hdt.event.CodingLinkedUpdateEvent
 import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.property.Coding
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.toPropertyValue
+import io.github.whdt.core.hdt.query.propertiesByCoding
+import io.github.whdt.distributed.serde.Stub
 import it.wldt.adapter.digital.event.DigitalActionWldtEvent
 import it.wldt.adapter.physical.PhysicalAssetAction
 import it.wldt.adapter.physical.PhysicalAssetDescription
@@ -21,6 +27,9 @@ import java.util.function.Consumer
 
 class WhdtShadowingFunction(id: String, val models: List<Model>): ShadowingFunction(id) {
     val logger: Logger = LoggerFactory.getLogger(WhdtShadowingFunction::class.java)
+
+    private lateinit var propertyByKey: Map<String, Property>
+    private lateinit var codingIndex: Map<Coding, List<Property>>
 
     override fun onCreate() {
         logger.debug("Shadowing - OnCreate")
@@ -104,6 +113,8 @@ class WhdtShadowingFunction(id: String, val models: List<Model>): ShadowingFunct
         } catch (e: java.lang.Exception) {
             logger.error(e.message, e)
         }
+
+        emitCodingLinkedUpdateIfAny(physicalPropertyEventMessage!!)
     }
 
     override fun onPhysicalAssetEventNotification(physicalAssetEventWldtEvent: PhysicalAssetEventWldtEvent<*>?) {
@@ -145,15 +156,49 @@ class WhdtShadowingFunction(id: String, val models: List<Model>): ShadowingFunct
     }
 
     private fun setupStartingModels() {
+        logger.debug("Setting up models for shadowing")
+        val allProps = models.flatMap { it.properties }
+        propertyByKey = allProps.associateBy { it.id.toString() }
+        codingIndex = allProps.propertiesByCoding()
+        logger.debug(
+            "Indexed {} properties; {} distinct codings",
+            propertyByKey.size, codingIndex.size,
+        )
+    }
 
-        logger.debug("Setting up models for shadowing");
+    private fun emitCodingLinkedUpdateIfAny(
+        physicalPropertyEventMessage: PhysicalAssetPropertyWldtEvent<*>,
+    ) {
+        val key = physicalPropertyEventMessage.physicalPropertyId
+        val source = propertyByKey[key] ?: return
+        val coding = source.coding ?: return
+        val siblings = (codingIndex[coding].orEmpty()).filter { it.id != source.id }
+        if (siblings.isEmpty()) return
 
-        this.models.forEach { m ->
-            try {
+        val newValue = physicalPropertyEventMessage.getBody().toPropertyValue() ?: run {
+            logger.warn(
+                "Coding-linked update suppressed: unsupported value type {} for property {}",
+                physicalPropertyEventMessage.getBody()?.javaClass, source.id,
+            )
+            return
+        }
 
-            } catch (e: Exception) {
-                logger.error("Error setting up model ${m.id}:\n${e.message}", e)
-            }
+        val payload = CodingLinkedUpdateEvent(
+            sourcePropertyId = source.id,
+            coding = coding,
+            linkedPropertyIds = siblings.map { it.id },
+            newValue = newValue,
+        )
+        try {
+            this.digitalTwinStateManager.notifyDigitalTwinStateEvent(
+                DigitalTwinStateEventNotification<String?>(
+                    CodingLinkedUpdateEvent.WLDT_EVENT_KEY,
+                    Stub.codingLinkedUpdateEventSerDe().serialize(payload),
+                    System.currentTimeMillis(),
+                )
+            )
+        } catch (e: WldtDigitalTwinStateEventNotificationException) {
+            logger.error("Failed to emit coding-linked update event: {}", e.message, e)
         }
     }
 
@@ -196,6 +241,21 @@ class WhdtShadowingFunction(id: String, val models: List<Model>): ShadowingFunct
                     logger.error("Error registering event for PAD: {}", id, ex)
                 }
             })
+
+            try {
+                if (!this.digitalTwinStateManager.digitalTwinState.containsEvent(CodingLinkedUpdateEvent.WLDT_EVENT_KEY)) {
+                    this.digitalTwinStateManager.registerEvent(
+                        DigitalTwinStateEvent(
+                            CodingLinkedUpdateEvent.WLDT_EVENT_KEY,
+                            "coding-linked-update",
+                        )
+                    )
+                }
+            } catch (e: WldtDigitalTwinStateException) {
+                logger.error("Error registering coding-linked-update event: {}", id, e)
+            } catch (e: WldtDigitalTwinStateEventException) {
+                logger.error("Error registering coding-linked-update event: {}", id, e)
+            }
 
             this.digitalTwinStateManager.commitStateTransaction()
 


### PR DESCRIPTION
Implements #64: Coding lookup primitives, linkage event, and `Any?.toPropertyValue()`.

## Files created/modified

**whdt-core**
- `hdt/model/property/PropertyValue.kt` — added `fun Any?.toPropertyValue()`
- `hdt/query/CodingQuery.kt` (new) — `List<Property>.findByCoding()` and `.propertiesByCoding()`
- `hdt/query/PropertyQuery.kt` — added HDT-level `findByCoding` and `propertiesByCoding`
- `hdt/event/CodingLinkedUpdateEvent.kt` (new) — serializable event payload
- Tests: `ToPropertyValueTest`, `CodingQueryTest`, `CodingLinkedUpdateEventTest`

**whdt-distributed**
- `serde/Stub.kt` — added `codingLinkedUpdateEventSerDe()`
- Tests: `TestSerDeCodingLinkedUpdateEvent`

**whdt-wldt-plugin**
- `shadowing/WhdtShadowingFunction.kt` — indexes, event registration, emission

## Notes
- Physical-property key convention (`Property.id.toString()`) verified
- `WhdtShadowingFunction` tests intentionally out of scope (follow-up issue will add plugin-side test harness)
- No direct `Json.encodeToString` in plugin — all serialization via `Stub.codingLinkedUpdateEventSerDe()`

Generated with [Claude Code](https://claude.ai/code)