### PR TITLE
feat: add View, ViewResult, and execute overloads for named query specs

### DIFF
--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/view/View.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/view/View.kt
@@ -1,0 +1,38 @@
+package io.github.whdt.core.hdt.view
+
+import io.github.whdt.core.hdt.query.TagPredicate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Identifier of a [View]. Globally identifying within whatever scope stores Views. */
+@JvmInline @Serializable
+value class ViewName(val value: String) {
+    init { require(value.isNotBlank()) { "ViewName must not be blank" } }
+    override fun toString(): String = value
+}
+
+/**
+ * A named, persistable query spec.
+ *
+ * Views are HDT-agnostic data: the same View runs against any [List]<[io.github.whdt.core.hdt.model.property.Property]>,
+ * a single [io.github.whdt.core.hdt.model.Model], a single [io.github.whdt.core.hdt.HumanDigitalTwin],
+ * or a [List]<[io.github.whdt.core.hdt.HumanDigitalTwin]> population. See `View.execute(...)` overloads.
+ *
+ * Execution semantics:
+ *  - If [predicate] is non-null, properties are filtered by it.
+ *  - If [groupByKeys] is empty, the result is [ViewResult.Flat]; otherwise it is a nested [ViewResult.Grouped]
+ *    one level deep per key in order. The null bucket at each level holds properties missing that tag key.
+ */
+@Serializable
+@SerialName("view")
+data class View(
+    val name: ViewName,
+    val predicate: TagPredicate? = null,
+    val groupByKeys: List<String> = emptyList(),
+) {
+    init {
+        require(groupByKeys.all { it.isNotBlank() }) {
+            "View '$name': groupByKeys must not contain blank entries: $groupByKeys"
+        }
+    }
+}

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/view/ViewExecution.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/view/ViewExecution.kt
@@ -1,0 +1,39 @@
+package io.github.whdt.core.hdt.view
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.query.allProperties
+import io.github.whdt.core.hdt.query.filterByTags
+import io.github.whdt.core.hdt.query.groupByTag
+
+/** Execute against an arbitrary property list. The base case all other overloads delegate to. */
+fun View.execute(properties: List<Property>): ViewResult {
+    val filtered = predicate?.let { properties.filterByTags(it) } ?: properties
+    return buildResult(filtered, groupByKeys)
+}
+
+private fun buildResult(properties: List<Property>, keys: List<String>): ViewResult {
+    if (keys.isEmpty()) return ViewResult.Flat(properties)
+    val head = keys.first()
+    val tail = keys.drop(1)
+    val grouped = properties.groupByTag(head)
+    return ViewResult.Grouped(
+        key = head,
+        buckets = grouped.mapValues { (_, props) -> buildResult(props, tail) },
+    )
+}
+
+/** Convenience: execute against a single Model. */
+fun View.execute(model: Model): ViewResult = execute(model.properties)
+
+/** Convenience: execute against a single HDT (all Models flattened). */
+fun View.execute(hdt: HumanDigitalTwin): ViewResult = execute(hdt.allProperties())
+
+/**
+ * Execute against an HDT population. Result is keyed by [HdtId] in the order HDTs appear in [population].
+ * Each entry is the View result for that HDT independently — no cross-HDT mixing.
+ */
+fun View.execute(population: List<HumanDigitalTwin>): Map<HdtId, ViewResult> =
+    population.associate { it.hdtId to execute(it) }

--- a/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/view/ViewResult.kt
+++ b/whdt-core/src/main/kotlin/io/github/whdt/core/hdt/view/ViewResult.kt
@@ -1,0 +1,89 @@
+package io.github.whdt.core.hdt.view
+
+import io.github.whdt.core.hdt.model.property.Property
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Recursive shape of a [View] execution output.
+ *  - [Flat]: leaf — a list of properties matching the View's predicate (or all, if no predicate)
+ *    after grouping has terminated.
+ *  - [Grouped]: a single level of grouping by tag [key]; each bucket value is itself a [ViewResult],
+ *    enabling arbitrary depth.
+ *
+ * Bucket maps preserve insertion order (LinkedHashMap) per Issue #2's [io.github.whdt.core.hdt.query.groupByTag] contract.
+ * The null map key represents properties missing the corresponding tag at that level.
+ *
+ * Serialization note: [Grouped.buckets] uses [BucketListSerializer] to serialize as a JSON array of
+ * {key, result} objects rather than a JSON object map. This avoids JSON's inability to represent null
+ * keys unambiguously in object notation, and preserves insertion order across the round-trip.
+ */
+@Serializable
+sealed interface ViewResult {
+
+    @Serializable
+    @SerialName("flat")
+    data class Flat(val properties: List<Property>) : ViewResult
+
+    @Serializable
+    @SerialName("grouped")
+    data class Grouped(
+        val key: String,
+        @Serializable(with = BucketListSerializer::class)
+        val buckets: Map<String?, ViewResult>,
+    ) : ViewResult
+}
+
+/** Internal representation used by [BucketListSerializer] to serialize a single bucket entry. */
+@Serializable
+internal data class Bucket(val key: String?, val result: ViewResult)
+
+/**
+ * Serializes [Map]<[String]?, [ViewResult]> as a JSON array of [Bucket] objects.
+ * This sidesteps JSON's restriction that object keys must be non-null strings, and
+ * preserves the [LinkedHashMap] insertion order across encode→decode round-trips.
+ */
+internal object BucketListSerializer : KSerializer<Map<String?, ViewResult>> {
+    private val delegate by lazy { ListSerializer(Bucket.serializer()) }
+    override val descriptor: SerialDescriptor get() = delegate.descriptor
+    override fun serialize(encoder: Encoder, value: Map<String?, ViewResult>) =
+        delegate.serialize(encoder, value.entries.map { (k, v) -> Bucket(k, v) })
+    override fun deserialize(decoder: Decoder): Map<String?, ViewResult> =
+        delegate.deserialize(decoder).associateTo(LinkedHashMap()) { it.key to it.result }
+}
+
+/**
+ * Walks every [ViewResult.Flat] leaf and invokes [action] with the path of bucket keys leading to it.
+ * The path is `List<String?>` because each level can have a null bucket; the path entry at level `i` is
+ * the bucket key under the i-th group-by axis.
+ *
+ * A [ViewResult.Flat] called directly invokes [action] with an empty path.
+ */
+fun ViewResult.walkLeaves(action: (path: List<String?>, properties: List<Property>) -> Unit) {
+    walkLeavesImpl(emptyList(), action)
+}
+
+private fun ViewResult.walkLeavesImpl(
+    path: List<String?>,
+    action: (path: List<String?>, properties: List<Property>) -> Unit,
+) {
+    when (this) {
+        is ViewResult.Flat    -> action(path, properties)
+        is ViewResult.Grouped -> buckets.forEach { (k, v) -> v.walkLeavesImpl(path + k, action) }
+    }
+}
+
+/**
+ * Flat-map convenience: every leaf path → its properties. Iteration order is depth-first, matching
+ * [walkLeaves]. The returned [LinkedHashMap] preserves that order.
+ */
+fun ViewResult.toFlatMap(): Map<List<String?>, List<Property>> {
+    val out = LinkedHashMap<List<String?>, List<Property>>()
+    walkLeaves { path, props -> out[path] = props }
+    return out
+}

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/view/ViewExecutionTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/view/ViewExecutionTest.kt
@@ -1,0 +1,210 @@
+package io.github.whdt.core.hdt.view
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.HumanDigitalTwin
+import io.github.whdt.core.hdt.model.Model
+import io.github.whdt.core.hdt.model.ModelDescription
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValueType
+import io.github.whdt.core.hdt.query.and
+import io.github.whdt.core.hdt.query.eq
+import io.github.whdt.core.hdt.query.has
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+
+class ViewExecutionTest : FunSpec({
+
+    // -------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------
+
+    val hdtId1 = HdtId("hdt-1")
+    val hdtId2 = HdtId("hdt-2")
+
+    fun modelId(hdtId: HdtId, name: String): ModelId = HdtIdFactory.modelId(hdtId, ModelName(name))
+
+    fun prop(name: String, modelId: ModelId, tags: Map<String, String> = emptyMap()) = Property(
+        modelId = modelId,
+        name = PropertyName(name),
+        description = PropertyDescription(""),
+        declaredType = PropertyValueType.STRING,
+        tags = tags,
+    )
+
+    fun model(hdtId: HdtId, name: String, props: List<Property>) = Model(
+        hdtId = hdtId,
+        name = ModelName(name),
+        description = ModelDescription(""),
+        properties = props,
+    )
+
+    fun hdt(hdtId: HdtId, vararg models: Model) = HumanDigitalTwin(hdtId = hdtId, models = models.toList())
+
+    // HDT 1: two motor props + one sensor prop
+    val m1Motor  = modelId(hdtId1, "motor")
+    val m1Sensor = modelId(hdtId1, "sensor")
+    val grasp1   = prop("grasp-force", m1Motor,  mapOf("domain" to "motor",  "task" to "grasp"))
+    val push1    = prop("push-torque", m1Motor,  mapOf("domain" to "motor",  "task" to "push"))
+    val eeg1     = prop("eeg-band",    m1Sensor, mapOf("domain" to "sensor"))
+    val hdt1     = hdt(
+        hdtId1,
+        model(hdtId1, "motor",  listOf(grasp1, push1)),
+        model(hdtId1, "sensor", listOf(eeg1)),
+    )
+
+    // HDT 2: motor props (one without task) + one sensor prop
+    val m2Motor  = modelId(hdtId2, "motor")
+    val m2Sensor = modelId(hdtId2, "sensor")
+    val grasp2   = prop("grasp-force", m2Motor,  mapOf("domain" to "motor",  "task" to "grasp"))
+    val rest2    = prop("rest-torque", m2Motor,  mapOf("domain" to "motor"))   // no task tag
+    val hr2      = prop("heart-rate",  m2Sensor, mapOf("domain" to "sensor", "task" to "rest"))
+    val hdt2     = hdt(
+        hdtId2,
+        model(hdtId2, "motor",  listOf(grasp2, rest2)),
+        model(hdtId2, "sensor", listOf(hr2)),
+    )
+
+    // -------------------------------------------------------------------------
+    // execute(List<Property>) — step 7
+    // -------------------------------------------------------------------------
+
+    context("execute(List<Property>)") {
+        test("no predicate no groupByKeys returns Flat of all input") {
+            val view = View(ViewName("all"))
+            view.execute(listOf(grasp1, push1)) shouldBe ViewResult.Flat(listOf(grasp1, push1))
+        }
+
+        test("predicate-only View returns Flat of filtered properties") {
+            val view = View(ViewName("motor"), eq("domain", "motor"))
+            view.execute(listOf(grasp1, push1, eeg1)) shouldBe ViewResult.Flat(listOf(grasp1, push1))
+        }
+
+        test("one-key groupByKeys returns Grouped with correct buckets") {
+            val view = View(ViewName("by-task"), groupByKeys = listOf("task"))
+            val result = view.execute(listOf(grasp1, push1)) as ViewResult.Grouped
+            result.key shouldBe "task"
+            result.buckets["grasp"] shouldBe ViewResult.Flat(listOf(grasp1))
+            result.buckets["push"]  shouldBe ViewResult.Flat(listOf(push1))
+        }
+
+        test("null bucket holds properties missing the group-by key") {
+            val view = View(ViewName("by-task"), groupByKeys = listOf("task"))
+            val result = view.execute(listOf(grasp1, eeg1)) as ViewResult.Grouped
+            result.buckets["grasp"] shouldBe ViewResult.Flat(listOf(grasp1))
+            result.buckets[null]    shouldBe ViewResult.Flat(listOf(eeg1))
+        }
+
+        test("two-key groupByKeys returns nested Grouped") {
+            val view = View(ViewName("two-key"), groupByKeys = listOf("domain", "task"))
+            val result = view.execute(listOf(grasp1, push1, eeg1)) as ViewResult.Grouped
+            result.key shouldBe "domain"
+            val motorBucket  = result.buckets["motor"]  as ViewResult.Grouped
+            val sensorBucket = result.buckets["sensor"] as ViewResult.Grouped
+            motorBucket.key shouldBe "task"
+            motorBucket.buckets["grasp"] shouldBe ViewResult.Flat(listOf(grasp1))
+            motorBucket.buckets["push"]  shouldBe ViewResult.Flat(listOf(push1))
+            sensorBucket.key shouldBe "task"
+            sensorBucket.buckets[null] shouldBe ViewResult.Flat(listOf(eeg1))
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // execute(Model) — step 8
+    // -------------------------------------------------------------------------
+
+    context("execute(Model)") {
+        test("delegates to execute(model.properties)") {
+            val view = View(ViewName("motor"), eq("domain", "motor"))
+            val motorModel = hdt1.models.first { it.name == ModelName("motor") }
+            view.execute(motorModel) shouldBe view.execute(motorModel.properties)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // execute(HumanDigitalTwin) — step 8
+    // -------------------------------------------------------------------------
+
+    context("execute(HumanDigitalTwin)") {
+        test("delegates to execute(hdt.allProperties())") {
+            val view = View(ViewName("motor"), eq("domain", "motor"))
+            view.execute(hdt1) shouldBe view.execute(listOf(grasp1, push1, eeg1))
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // execute(List<HumanDigitalTwin>) — step 9
+    // -------------------------------------------------------------------------
+
+    context("execute(List<HumanDigitalTwin>)") {
+        val motorView = View(ViewName("motor"), eq("domain", "motor"))
+
+        test("empty population returns empty map") {
+            motorView.execute(emptyList<HumanDigitalTwin>()).shouldBeEmpty()
+        }
+
+        test("population result is keyed by HdtId in input order") {
+            val result = motorView.execute(listOf(hdt1, hdt2))
+            result.keys.toList() shouldBe listOf(hdtId1, hdtId2)
+        }
+
+        test("each entry is the View result for that HDT independently") {
+            val result = motorView.execute(listOf(hdt1, hdt2))
+            result[hdtId1] shouldBe motorView.execute(hdt1)
+            result[hdtId2] shouldBe motorView.execute(hdt2)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Integration test — preterm-style population scenario — step 10
+    // -------------------------------------------------------------------------
+
+    context("Integration — population-scale preterm scenario") {
+        val motorByTask = View(
+            name = ViewName("motor-by-task"),
+            predicate = eq("domain", "motor"),
+            groupByKeys = listOf("task"),
+        )
+
+        test("result map contains both HDT IDs") {
+            val result = motorByTask.execute(listOf(hdt1, hdt2))
+            result shouldContainKey hdtId1
+            result shouldContainKey hdtId2
+        }
+
+        test("each value is a Grouped keyed on task") {
+            val result = motorByTask.execute(listOf(hdt1, hdt2))
+            (result[hdtId1] as? ViewResult.Grouped)?.key shouldBe "task"
+            (result[hdtId2] as? ViewResult.Grouped)?.key shouldBe "task"
+        }
+
+        test("hdt1 bucket counts: grasp and push buckets, no null bucket") {
+            val grouped = motorByTask.execute(listOf(hdt1, hdt2))[hdtId1] as ViewResult.Grouped
+            grouped.buckets["grasp"] shouldBe ViewResult.Flat(listOf(grasp1))
+            grouped.buckets["push"]  shouldBe ViewResult.Flat(listOf(push1))
+            grouped.buckets.keys.toList() shouldBe listOf("grasp", "push")
+        }
+
+        test("hdt2 has null bucket for motor prop without task") {
+            val grouped = motorByTask.execute(listOf(hdt1, hdt2))[hdtId2] as ViewResult.Grouped
+            grouped.buckets["grasp"] shouldBe ViewResult.Flat(listOf(grasp2))
+            grouped.buckets[null]    shouldBe ViewResult.Flat(listOf(rest2))
+        }
+
+        test("walkLeaves over hdt1 result yields expected paths") {
+            val grouped = motorByTask.execute(listOf(hdt1, hdt2))[hdtId1] as ViewResult.Grouped
+            val leaves = mutableListOf<Pair<List<String?>, List<Property>>>()
+            grouped.walkLeaves { path, props -> leaves += path to props }
+            leaves shouldBe listOf(
+                listOf("grasp") to listOf(grasp1),
+                listOf("push")  to listOf(push1),
+            )
+        }
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/view/ViewResultTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/view/ViewResultTest.kt
@@ -1,0 +1,225 @@
+package io.github.whdt.core.hdt.view
+
+import io.github.whdt.core.hdt.HdtId
+import io.github.whdt.core.hdt.HdtIdFactory
+import io.github.whdt.core.hdt.model.ModelId
+import io.github.whdt.core.hdt.model.ModelName
+import io.github.whdt.core.hdt.model.property.Property
+import io.github.whdt.core.hdt.model.property.PropertyDescription
+import io.github.whdt.core.hdt.model.property.PropertyName
+import io.github.whdt.core.hdt.model.property.PropertyValueType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class ViewResultTest : FunSpec({
+
+    val hdtId = HdtId("test-hdt")
+    val modelId: ModelId = HdtIdFactory.modelId(hdtId, ModelName("m"))
+
+    fun prop(name: String, tags: Map<String, String> = emptyMap()) = Property(
+        modelId = modelId,
+        name = PropertyName(name),
+        description = PropertyDescription(""),
+        declaredType = PropertyValueType.STRING,
+        tags = tags,
+    )
+
+    val json = Json { encodeDefaults = true }
+
+    fun roundTrip(result: ViewResult): ViewResult =
+        json.decodeFromString<ViewResult>(json.encodeToString<ViewResult>(result))
+
+    // -------------------------------------------------------------------------
+    // Structural tests — step 3
+    // -------------------------------------------------------------------------
+
+    context("ViewResult structural") {
+        test("Flat can be constructed") {
+            val p = prop("p1")
+            val flat = ViewResult.Flat(listOf(p))
+            flat.properties shouldBe listOf(p)
+        }
+
+        test("Grouped can be constructed with non-null bucket key") {
+            val flat = ViewResult.Flat(listOf(prop("p1")))
+            val grouped = ViewResult.Grouped("task", mapOf("grasp" to flat))
+            grouped.key shouldBe "task"
+            grouped.buckets["grasp"] shouldBe flat
+        }
+
+        test("Grouped allows null bucket key") {
+            val flat = ViewResult.Flat(emptyList())
+            val grouped = ViewResult.Grouped("task", mapOf(null to flat))
+            grouped.buckets[null] shouldBe flat
+        }
+
+        test("recursive nesting is allowed by the type system") {
+            val inner = ViewResult.Grouped("task", mapOf("grasp" to ViewResult.Flat(listOf(prop("p1")))))
+            val outer = ViewResult.Grouped("domain", mapOf("motor" to inner))
+            (outer.buckets["motor"] as ViewResult.Grouped).key shouldBe "task"
+        }
+
+        test("structural equality holds for Flat") {
+            val p = prop("p1")
+            ViewResult.Flat(listOf(p)) shouldBe ViewResult.Flat(listOf(p))
+        }
+
+        test("structural equality holds for Grouped") {
+            val flat = ViewResult.Flat(listOf(prop("p1")))
+            ViewResult.Grouped("task", mapOf("grasp" to flat)) shouldBe
+                ViewResult.Grouped("task", mapOf("grasp" to flat))
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON round-trip — step 4
+    // -------------------------------------------------------------------------
+
+    context("ViewResult JSON round-trip") {
+        test("Flat round-trips") {
+            val flat = ViewResult.Flat(listOf(prop("p1")))
+            roundTrip(flat) shouldBe flat
+        }
+
+        test("single-level Grouped with non-null bucket key round-trips") {
+            val grouped = ViewResult.Grouped(
+                key = "task",
+                buckets = linkedMapOf("grasp" to ViewResult.Flat(listOf(prop("p1")))),
+            )
+            roundTrip(grouped) shouldBe grouped
+        }
+
+        test("single-level Grouped with null bucket key round-trips") {
+            val grouped = ViewResult.Grouped(
+                key = "task",
+                buckets = linkedMapOf(null to ViewResult.Flat(listOf(prop("p1")))),
+            )
+            val decoded = roundTrip(grouped)
+            decoded shouldBe grouped
+            (decoded as ViewResult.Grouped).buckets shouldContainKey null
+        }
+
+        test("null bucket key survives round-trip — explicit order check") {
+            val grouped = ViewResult.Grouped(
+                key = "domain",
+                buckets = linkedMapOf(
+                    "motor"  to ViewResult.Flat(listOf(prop("p1"))),
+                    null     to ViewResult.Flat(listOf(prop("p2"))),
+                    "sensor" to ViewResult.Flat(listOf(prop("p3"))),
+                ),
+            )
+            val decoded = roundTrip(grouped) as ViewResult.Grouped
+            decoded.buckets.keys.toList() shouldBe listOf("motor", null, "sensor")
+        }
+
+        test("3-level nested Grouped round-trips preserving insertion order at depth >= 3") {
+            val p1 = prop("p1")
+            val p2 = prop("p2")
+            val p3 = prop("p3")
+            val p4 = prop("p4")
+            val level2a = ViewResult.Grouped("task", linkedMapOf(
+                "grasp" to ViewResult.Flat(listOf(p1)),
+                null    to ViewResult.Flat(listOf(p2)),
+            ))
+            val level2b = ViewResult.Grouped("task", linkedMapOf(
+                "push" to ViewResult.Flat(listOf(p3)),
+                "rest" to ViewResult.Flat(listOf(p4)),
+            ))
+            val level1 = ViewResult.Grouped("domain", linkedMapOf(
+                "motor"  to level2a,
+                "sensor" to level2b,
+            ))
+
+            val decoded = roundTrip(level1) as ViewResult.Grouped
+            decoded shouldBe level1
+
+            // Explicitly assert insertion order at each level
+            decoded.buckets.keys.toList() shouldBe listOf("motor", "sensor")
+            (decoded.buckets["motor"] as ViewResult.Grouped).buckets.keys.toList() shouldBe listOf("grasp", null)
+            (decoded.buckets["sensor"] as ViewResult.Grouped).buckets.keys.toList() shouldBe listOf("push", "rest")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // walkLeaves — step 5
+    // -------------------------------------------------------------------------
+
+    context("walkLeaves") {
+        test("Flat invokes action once with empty path") {
+            val p = prop("p1")
+            val calls = mutableListOf<Pair<List<String?>, List<Property>>>()
+            ViewResult.Flat(listOf(p)).walkLeaves { path, props -> calls += path to props }
+            calls.size shouldBe 1
+            calls[0].first shouldBe emptyList()
+            calls[0].second shouldBe listOf(p)
+        }
+
+        test("2-level Grouped invokes action for each leaf with 2-element path") {
+            val p1 = prop("p1")
+            val p2 = prop("p2")
+            val grouped = ViewResult.Grouped("domain", linkedMapOf(
+                "motor"  to ViewResult.Grouped("task", linkedMapOf("grasp" to ViewResult.Flat(listOf(p1)))),
+                "sensor" to ViewResult.Grouped("task", linkedMapOf("rest"  to ViewResult.Flat(listOf(p2)))),
+            ))
+            val calls = mutableListOf<Pair<List<String?>, List<Property>>>()
+            grouped.walkLeaves { path, props -> calls += path to props }
+            calls.size shouldBe 2
+            calls[0].first shouldBe listOf("motor", "grasp")
+            calls[0].second shouldBe listOf(p1)
+            calls[1].first shouldBe listOf("sensor", "rest")
+            calls[1].second shouldBe listOf(p2)
+        }
+
+        test("null bucket key appears as null in the path") {
+            val p = prop("p1")
+            val grouped = ViewResult.Grouped("task", linkedMapOf(null to ViewResult.Flat(listOf(p))))
+            val calls = mutableListOf<Pair<List<String?>, List<Property>>>()
+            grouped.walkLeaves { path, props -> calls += path to props }
+            calls[0].first shouldBe listOf<String?>(null)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // toFlatMap — step 5
+    // -------------------------------------------------------------------------
+
+    context("toFlatMap") {
+        test("Flat returns single entry with empty path key") {
+            val p = prop("p1")
+            ViewResult.Flat(listOf(p)).toFlatMap() shouldBe mapOf(emptyList<String?>() to listOf(p))
+        }
+
+        test("returns same paths and properties as walkLeaves in order") {
+            val p1 = prop("p1")
+            val p2 = prop("p2")
+            val grouped = ViewResult.Grouped("task", linkedMapOf(
+                "grasp" to ViewResult.Flat(listOf(p1)),
+                null    to ViewResult.Flat(listOf(p2)),
+            ))
+            val fromWalkLeaves = LinkedHashMap<List<String?>, List<Property>>()
+            grouped.walkLeaves { path, props -> fromWalkLeaves[path] = props }
+            grouped.toFlatMap() shouldBe fromWalkLeaves
+        }
+
+        test("preserves depth-first order") {
+            val p1 = prop("p1")
+            val p2 = prop("p2")
+            val p3 = prop("p3")
+            val grouped = ViewResult.Grouped("domain", linkedMapOf(
+                "motor"  to ViewResult.Grouped("task", linkedMapOf(
+                    "grasp" to ViewResult.Flat(listOf(p1)),
+                    "push"  to ViewResult.Flat(listOf(p2)),
+                )),
+                "sensor" to ViewResult.Flat(listOf(p3)),
+            ))
+            grouped.toFlatMap().keys.toList() shouldBe listOf(
+                listOf("motor", "grasp"),
+                listOf("motor", "push"),
+                listOf("sensor"),
+            )
+        }
+    }
+})

--- a/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/view/ViewTest.kt
+++ b/whdt-core/src/test/kotlin/io/github/whdt/core/hdt/view/ViewTest.kt
@@ -1,0 +1,90 @@
+package io.github.whdt.core.hdt.view
+
+import io.github.whdt.core.hdt.query.eq
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class ViewTest : FunSpec({
+
+    val json = Json { encodeDefaults = true }
+
+    // -------------------------------------------------------------------------
+    // ViewName — step 1
+    // -------------------------------------------------------------------------
+
+    context("ViewName") {
+        test("accepts non-blank value") {
+            ViewName("motor").value shouldBe "motor"
+        }
+
+        test("rejects blank string") {
+            shouldThrow<IllegalArgumentException> { ViewName("") }
+        }
+
+        test("rejects whitespace-only string") {
+            shouldThrow<IllegalArgumentException> { ViewName("   ") }
+        }
+
+        test("toString returns the raw value") {
+            ViewName("motor").toString() shouldBe "motor"
+        }
+
+        test("equality via underlying value") {
+            ViewName("motor") shouldBe ViewName("motor")
+        }
+
+        test("JSON round-trip") {
+            val name = ViewName("motor")
+            val encoded = json.encodeToString(name)
+            json.decodeFromString<ViewName>(encoded) shouldBe name
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // View data class — step 2
+    // -------------------------------------------------------------------------
+
+    context("View") {
+        test("construction with all defaults") {
+            val v = View(ViewName("test"))
+            v.name shouldBe ViewName("test")
+            v.predicate shouldBe null
+            v.groupByKeys shouldBe emptyList()
+        }
+
+        test("construction with all fields set") {
+            val pred = eq("domain", "motor")
+            val v = View(ViewName("motor-by-task"), pred, listOf("task", "visit"))
+            v.name shouldBe ViewName("motor-by-task")
+            v.predicate shouldBe pred
+            v.groupByKeys shouldBe listOf("task", "visit")
+        }
+
+        test("rejects blank groupByKeys entry") {
+            shouldThrow<IllegalArgumentException> { View(ViewName("v"), groupByKeys = listOf("")) }
+        }
+
+        test("rejects whitespace-only groupByKeys entry") {
+            shouldThrow<IllegalArgumentException> { View(ViewName("v"), groupByKeys = listOf("task", "   ")) }
+        }
+
+        test("structural equality") {
+            val v1 = View(ViewName("motor"), eq("domain", "motor"), listOf("task"))
+            val v2 = View(ViewName("motor"), eq("domain", "motor"), listOf("task"))
+            v1 shouldBe v2
+        }
+
+        test("JSON round-trip with defaults") {
+            val v = View(ViewName("all"))
+            json.decodeFromString<View>(json.encodeToString(v)) shouldBe v
+        }
+
+        test("JSON round-trip with non-null predicate and multi-key groupByKeys") {
+            val v = View(ViewName("motor-by-task"), eq("domain", "motor"), listOf("task", "visit"))
+            json.decodeFromString<View>(json.encodeToString(v)) shouldBe v
+        }
+    }
+})


### PR DESCRIPTION
Closes #66

## Summary

- Adds `whdt-core/hdt/view/` package with `View.kt`, `ViewResult.kt`, `ViewExecution.kt`
- `View` is HDT-agnostic: no `hdtId` field; the same View runs against a property list, Model, HDT, or population
- `ViewResult.Grouped.buckets` uses `BucketListSerializer` (JSON array of {key,result}) to handle null keys and preserve insertion order
- No storage abstraction; persistence is a deferred follow-up

Generated with [Claude Code](https://claude.ai/code)